### PR TITLE
Create cloudformations for web component infrastructure

### DIFF
--- a/deploy/cloudformation/data-broker.yml
+++ b/deploy/cloudformation/data-broker.yml
@@ -1,0 +1,47 @@
+
+Parameters:
+
+  InfrastructureStackName:
+    Type: String
+    Default: mellon-infrastructure
+    Description: The name of the parent infrastructure/networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+
+Outputs:
+
+  PublicBucket:
+    Description: A temporary bucket to share assets publicly for Mellon project
+    Value: !Ref PublicBucket
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicBucket']]
+
+Resources:
+
+  PublicBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders: ['*']
+            AllowedOrigins: ['http://universalviewer.io', '*.cloudfront.net']
+            AllowedMethods: [GET]
+            MaxAge: 3600
+      LoggingConfiguration:
+        DestinationBucketName:
+          Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
+        LogFilePrefix: s3/data-broker/
+      WebsiteConfiguration:
+        IndexDocument: index.html
+
+  PublicBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref PublicBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub ${PublicBucket.Arn}/*
+            Principal: '*'

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -23,6 +23,9 @@ Parameters:
     Default: mellon-infrastructure
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
+  ImageSourceBucket:
+    Type: String
+    Description: The name of the source bucket that the IIIF service will read from for its assets.
   ImageUrl:
     Type: String
     Default: ndlib/image-service
@@ -68,6 +71,14 @@ Parameters:
     Type: String
     Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
 
+Outputs:
+  PublicLoadBalancerDNSName:
+    Description: The dns name of the load balancer
+    Value: !GetAtt PublicLoadBalancer.DNSName
+  ImageDerivativeCacheBucketName:
+    Description: The name of the bucket that will be used as the source/destination for derivative images
+    Value: !Ref ImageDerivativeCacheBucket
+
 Resources:
 
   # The task definition. This is a simple metadata description of what
@@ -75,7 +86,6 @@ Resources:
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     DependsOn:
-      - ImageSourceBucket
       - ImageServiceLogGroup
       - ImageServiceTaskRole
     Properties:
@@ -212,10 +222,6 @@ Resources:
       ListenerArn: !Ref 'PublicLoadBalancerListener'
       Priority: !Ref 'Priority'
 
-  ImageSourceBucket:
-    Type: AWS::S3::Bucket
-    Description: This is the source bucket that the IIIF service will read from for its assets.
-
   ImageDerivativeCacheBucket:
     Type: AWS::S3::Bucket
     Description: This is the target bucket that the IIIF service will write to when it generates its cache of derivative.
@@ -229,7 +235,6 @@ Resources:
   ImageServiceTaskRole:
     Type: AWS::IAM::Role
     DependsOn:
-      - ImageSourceBucket
       - ImageDerivativeCacheBucket
     Properties:
       Path: /
@@ -256,7 +261,7 @@ Resources:
                   Fn::Join:
                     - ""
                     -
-                      - !GetAtt ImageSourceBucket.Arn
+                      - !Sub "arn:aws:s3:::${ImageSourceBucket}"
                       - "/*"
         - PolicyName: ImageDerivativeCacheBucketPermissions
           PolicyDocument:
@@ -277,14 +282,3 @@ Resources:
                       -
                         - !GetAtt ImageDerivativeCacheBucket.Arn
                         - "/*"
-
-Outputs:
-  PublicLoadBalancerDNSName:
-    Description: The dns name of the load balancer
-    Value: !GetAtt PublicLoadBalancer.DNSName
-  ImageSourceBucketName:
-    Description: The name of the bucket that will be used as the source for image files
-    Value: !Ref ImageSourceBucket
-  ImageDerivativeCacheBucketName:
-    Description: The name of the bucket that will be used as the source/destination for derivative images
-    Value: !Ref ImageDerivativeCacheBucket

--- a/deploy/cloudformation/iiif-webcomponent.yml
+++ b/deploy/cloudformation/iiif-webcomponent.yml
@@ -1,0 +1,159 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+
+Description: 'Static host for IIIF webcomponents'
+
+
+Parameters:
+
+  InfrastructureStackName:
+    Type: String
+    Default: mellon-infrastructure
+    Description: The name of the parent infrastructure/networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+
+  AcmCertificateArn:
+    Type: String
+    Description: Arn for ACM Certificate
+    Default: ''
+
+  FQDN:
+    Type: String
+    Description: DNS name for the website to publish
+    MaxLength: 63
+    AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: must be a valid DNS zone name
+    Default: ''
+
+  EnvType:
+    Type: String
+    Description: The type of environment to create.
+    Default: dev
+    AllowedValues:
+      - dev
+      - prod
+    ConstraintDescription: must specify prod or dev.
+
+Mappings:
+  # Cache settings to use for each environment
+  CacheSettings:
+    dev:
+      DefaultTTL: 0
+    prod:
+      DefaultTTL: 86400
+
+Conditions:
+
+  NoFQDN: !Equals
+    - !Ref FQDN
+    - ''
+
+  NoSSL: !Equals
+    - !Ref AcmCertificateArn
+    - ''
+
+Outputs:
+
+  BucketName:
+    Description: Name of S3 bucket to hold website content
+    Value: !Ref Bucket
+
+  CNAME:
+    Description: Website CNAME target
+    Value: !GetAtt Distribution.DomainName
+
+Resources:
+
+  OriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: IIIF Web Component Origin Access Identity
+
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      LoggingConfiguration:
+        DestinationBucketName:
+          Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
+        LogFilePrefix: !If
+          - NoFQDN
+          - s3/iiif-webcomponent/
+          - !Sub s3/${FQDN}/
+
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DependsOn: OriginAccessIdentity
+    Properties:
+      Bucket: !Ref Bucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub ${Bucket.Arn}/*
+            Principal:
+              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
+
+  Distribution:
+    Type: AWS::CloudFront::Distribution
+    DependsOn: OriginAccessIdentity
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        HttpVersion: http2
+        PriceClass: PriceClass_100
+        ViewerCertificate: !If
+          - NoSSL
+          - !Ref AWS::NoValue
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            MinimumProtocolVersion: TLSv1.1_2016
+            SslSupportMethod: sni-only
+        Comment: !If
+          - NoFQDN
+          - !Ref AWS::NoValue
+          - !Ref FQDN
+        Aliases: !If
+          - NoFQDN
+          - !Ref AWS::NoValue
+          - - !Ref FQDN
+        DefaultRootObject: index.html
+        DefaultCacheBehavior:
+          ForwardedValues:
+            QueryString: false
+          AllowedMethods:
+            - HEAD
+            - GET
+            - OPTIONS
+          Compress: true
+          DefaultTTL: !FindInMap [CacheSettings, !Ref EnvType, "DefaultTTL"]
+          ViewerProtocolPolicy: !If
+            - NoSSL
+            - allow-all
+            - redirect-to-https
+          TargetOriginId: Bucket
+        Origins:
+          - Id: Bucket
+            DomainName: !GetAtt Bucket.DomainName
+            S3OriginConfig:
+              OriginAccessIdentity: !Join
+                - /
+                - - origin-access-identity
+                  - cloudfront
+                  - !Ref OriginAccessIdentity
+        Logging:
+          # This should result in "logbucketname.s3.amazonaws.com", where "logbucketname" is the value from an export
+          # named "InfrastructureStackName:LogBucket"
+          Bucket: !Join
+            - .
+            - - !ImportValue
+                Fn::Join: [':', [!Ref InfrastructureStackName, 'LogBucket']]
+              - s3
+              - !Ref AWS::URLSuffix
+          Prefix: !If
+            - NoFQDN
+            - web/iiif-webcomponent/
+            - !Sub web/${FQDN}/
+          IncludeCookies: true

--- a/deploy/cloudformation/infrastructure.yml
+++ b/deploy/cloudformation/infrastructure.yml
@@ -67,6 +67,68 @@ Parameters:
     Type: String
     Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
 
+Outputs:
+
+  ClusterName:
+    Description: The name of the ECS Cluster created by this CloudFormation
+    Value: !Ref ContainerCluster
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ClusterName']]
+
+  PublicSubnet1ID:
+    Description: The subnet ID of the 1st public subnet
+    Value: !Ref PublicSubnet1
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicSubnet1ID']]
+
+  PublicSubnet2ID:
+    Description: The subnet ID of the 2nd public subnet
+    Value: !Ref PublicSubnet2
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicSubnet2ID']]
+
+  PrivateSubnet1ID:
+    Description: The subnet ID of the 1st private subnet
+    Value: !Ref PrivateSubnet1
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PrivateSubnet1ID']]
+
+  PrivateSubnet2ID:
+    Description: The subnet ID of the 2nd private subnet
+    Value: !Ref PrivateSubnet2
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PrivateSubnet2ID']]
+
+  IIIFSecurityGroupID:
+    Description: The Security Group ID for the IIIF Service
+    Value: !Ref IIIFSecurityGroup
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'IIIFSecurityGroupID']]
+
+  ContainerTaskExecutionRoleArn:
+    Description: The ARN (Amazon Resource Name) of the Container Task Execution Role
+    Value: !GetAtt ContainerTaskExecutionRole.Arn
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ContainerTaskExecutionRoleArn']]
+
+  VPCID:
+    Description: The ID of the created VPC
+    Value: !Ref VPC
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'VPCID']]
+
+  PublicLoadBalancerSecurityGroupID:
+    Description: The ID of the load balancer security group
+    Value: !Ref PublicLoadBalancerSecurityGroup
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicLoadBalancerSecurityGroup']]
+
+  LogBucket:
+    Description: Bucket to put all logs into for this application
+    Value: !Ref LogBucket
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'LogBucket']]
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -252,9 +314,9 @@ Resources:
       VpcId: !Ref VPC
       GroupDescription: Access to a public facing load balancer
       SecurityGroupIngress:
-          # Allow access to ALB from anywhere on the internet
-          - CidrIp: 0.0.0.0/0
-            IpProtocol: "-1"
+        # Allow access to ALB from anywhere on the internet
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: "-1"
 
       Tags:
         - Key: Name
@@ -341,59 +403,14 @@ Resources:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: "*"
-
-Outputs:
-
-  ClusterName:
-    Description: The name of the ECS Cluster created by this CloudFormation
-    Value: !Ref ContainerCluster
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ClusterName']]
-
-  PublicSubnet1ID:
-    Description: The subnet ID of the 1st public subnet
-    Value: !Ref PublicSubnet1
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicSubnet1ID']]
-
-  PublicSubnet2ID:
-    Description: The subnet ID of the 2nd public subnet
-    Value: !Ref PublicSubnet2
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicSubnet2ID']]
-
-  PrivateSubnet1ID:
-    Description: The subnet ID of the 1st private subnet
-    Value: !Ref PrivateSubnet1
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PrivateSubnet1ID']]
-
-  PrivateSubnet2ID:
-    Description: The subnet ID of the 2nd private subnet
-    Value: !Ref PrivateSubnet2
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PrivateSubnet2ID']]
-
-  IIIFSecurityGroupID:
-    Description: The Security Group ID for the IIIF Service
-    Value: !Ref IIIFSecurityGroup
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'IIIFSecurityGroupID']]
-
-  ContainerTaskExecutionRoleArn:
-    Description: The ARN (Amazon Resource Name) of the Container Task Execution Role
-    Value: !GetAtt ContainerTaskExecutionRole.Arn
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ContainerTaskExecutionRoleArn']]
-
-  VPCID:
-    Description: The ID of the created VPC
-    Value: !Ref VPC
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'VPCID']]
-
-  PublicLoadBalancerSecurityGroupID:
-    Description: The ID of the load balancer security group
-    Value: !Ref PublicLoadBalancerSecurityGroup
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PublicLoadBalancerSecurityGroup']]
+  LogBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: LogDeliveryWrite
+      VersioningConfiguration:
+        Status: Suspended
+      LifecycleConfiguration:
+        Rules:
+        - Status: Enabled
+          ExpirationInDays: 3653
+          NoncurrentVersionExpirationInDays: 1


### PR DESCRIPTION
## Create cloudformations for web component infrastructure

1aaf977033f951355383b6be205cac741fc9e2c5

- First, a bit of cleanup:
  - Renamed the iiif-service-stack.yml. Removed the -stack suffix as redundant.
  - Fixed a few style issues in the cloudformations, including moving Outputs to the top and fixing spacing to match the majority of our other CFNs
- Created a data-broker cloudformation to create the public bucket that will temporarily host the images and manifests for testing. For now this has a CORS configuration on the bucket and cloudfront that's limited to allow universalviewer.io and our webcomponent cloudfront to retrieve a manifest json from the bucket. I expect this cloudformation to be completely rewritten once we understand what infrastructure we need for the data broker
- Since the image source bucket is now in the data-broker stack, removed the image source bucket from the iiif-service stack. Now expects this as a parameter
- Added a log bucket to the base infrastructure stack. Services that use this will be expected to namespace/partition accordingly inside this log bucket.
- Created a webcomponent stack that creates a bucket and a cloudfront for hosting the webcomponent html/js files. Something to note is that the cloudfront configuration will not use caching in development, but should in production. It does this via a configuration map based on the EnvType parameter.