### PR TITLE
MEL-3 Fix pipeline build

### DIFF
--- a/deploy/cloudformation/iiif-webcomponent-pipeline.yml
+++ b/deploy/cloudformation/iiif-webcomponent-pipeline.yml
@@ -136,19 +136,20 @@ Resources:
             install:
               commands:
                 - echo Install started on `date`
-                - sh build/install.sh
+                - chmod -R 755 build/*
+                - ./build/install.sh
             pre_build:
               commands:
                 - echo Pre-build started on `date`
-                - sh build/pre_build.sh
+                - ./build/pre_build.sh
             build:
               commands:
                 - echo Build started on `date`
-                - sh build/build.sh
+                - ./build/build.sh
             post_build:
               commands:
                 - echo Beginning post build on `date`
-                - sh build/post_build.sh
+                - ./build/post_build.sh
           artifacts:
             base-directory: dist
             files:


### PR DESCRIPTION
## Fixing permissions on build scripts

ef112ea3bbd6fcb074f982806c37a23eb51c589c

Pipeline was dying when trying to execute child build scripts (ex: /build/react/build.sh). To keep things simple and project agnostic, just adding execute permissions to all files under /build during install.