### PR TITLE
MEL-3: Updating the test URL

### DIFF
--- a/deploy/cloudformation/iiif-webcomponent-pipeline.yml
+++ b/deploy/cloudformation/iiif-webcomponent-pipeline.yml
@@ -56,15 +56,15 @@ Parameters:
     Description: The path to the param that stores the test URL.
     Default: "/all/stacks/mellon-image-webcomponent-test/url"
 
-  TestManifestURL:
-    Type: String
-    Description: The URL of the manifest to use when notifying approvers of a change
-    Default: ""
-
   ProdDeployBucket:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Description: The path to the param that stores the test deployment bucket.
     Default: "/all/stacks/mellon-image-webcomponent-prod/bucket"
+
+  ProdURL:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: The path to the param that stores the test URL.
+    Default: "/all/stacks/mellon-image-webcomponent-prod/url"
 
 Resources:
   SNSTopic:
@@ -491,7 +491,7 @@ Resources:
                 Version: "1"
               Configuration:
                 NotificationArn: !Ref SNSTopic
-                CustomData: !Sub "You can review these changes at https://${TestURL}/universalviewer/index.html#?manifest=${TestManifestURL}"
+                CustomData: !Sub "You can review these changes at https://${TestURL}. Once approved, this will be deployed to https://${ProdURL}."
 
         -
           Name: DeployToProduction


### PR DESCRIPTION
## Updating the test URL

0c86d3f4fedf5d402e8f1e004c181ab4c7295523

- The viewer is now wrapped in a React component with an index.html at the root (see https://github.com/ndlib/image-viewer/pull/9), so no longer need to navigate into universalviewer. Updated the test URL to match.
- Also, in lieu of having a notification post "deploy to production", added the prod URL to the email to let the users know where it will be deployed when they accept.