### PR TITLE
Mellon to marble name change

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -49,7 +49,7 @@ Parameters:
   ConfigurationRepoName:
     Type: String
     Description: The GitHub repo for the cloudfromation blueprints
-    Default: mellon-blueprints
+    Default: marble-blueprints
   ConfigurationRepoBranchName:
     Type: String
     Description: The GitHub repo branch the codepipeline should checkout to run blueprints from


### PR DESCRIPTION
Now that the configuration repo’s name has changed, updating the default in the manifest deployment pipeline.