### PR TITLE
Fix network template path collision

### DIFF
--- a/deploy/cloudformation/export-existing-network.yml
+++ b/deploy/cloudformation/export-existing-network.yml
@@ -43,7 +43,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: /all/vpcid
+      Name: !Sub '/all/stacks/${AWS::StackName}/vpcid'
       Description: The VPCID to use for existing resources
       Value: !Ref VPC
 


### PR DESCRIPTION
This template is creating an SSM resource with a constant path, meaning we can't deploy another instance of this template without destroying others. Changed to namespace it by stack name.