### PR TITLE
Fix ssm permissions on Manifest Pipeline

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -198,6 +198,8 @@ Resources:
             - 'ssm:Delete*'
             - 'ssm:Put*'
             - 'ssm:AddTags*'
+            - 'ssm:RemoveTagsFromResource'
+            - 'ssm:GetParameters'
             Resource:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${TestStackName}/*"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${ProdStackName}/*"


### PR DESCRIPTION
The recent redeploy required first deploying with a dummy hostname prefix, then redeploying with the new one once dns was changed. This caused the manifest deployment pipeline to remove tags and change ssm parameters, which hit unforeseen permissions issues. This change fixes the immediate issues I encountered.