### PR TITLE
adding additional CORS header for Curate integration

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -156,6 +156,14 @@ Resources:
             AllowedOrigins:
               - '*'
             MaxAge: 3000
+          - Id: CSRFCorsHeader
+            AllowedHeaders:
+              - X-CSRF-Token
+            AllowedMethods:
+              - GET
+              - HEAD
+            AllowedOrigins:
+              - '*'
   ManifestBucketPolicy:
     Type: AWS::S3::BucketPolicy
     DependsOn: OriginAccessIdentity


### PR DESCRIPTION
For the CurateND Image Viewer integration, we discovered that the headers being sent by the application were not the `Authorization` headers being used elsewhere, but rather were `X-CSRF-Token`.

This updates the Manifest bucket to allow these CORS headers so Curate can show the ImageViewer in an iFrame.