### PR TITLE
add IAM permissions for step function updates

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -146,6 +146,7 @@ Resources:
               - 'states:CreateStateMachine'
               - 'states:DeleteStateMachine'
               - 'states:TagResource'
+              - 'states:UpdateStateMachine'
             Resource:
               - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:*'
             Effect: 'Allow'


### PR DESCRIPTION
The CodePipeline is currently in a broken state due to the inability to update the State Machine for Step Functions. 

Breaking changes took place with #70 and the changes to the step functions.

This PR will add the needed permissions to allow the trust role to update the State Machine and allow the Code Pipeline to finish.