### PR TITLE
Group Approval with Test deployment stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ How to build the Primo Passthrough Pipeline
 ```console
 aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM \
-  --stack-name mellon-passthrough-pipeline \
+  --stack-name marble-passthrough-pipeline \
   --template-file deploy/cloudformation/manifest-passthrough-pipeline.yml \
-  --tags Name='mellon-passthrough-pipeline' Contact='me@myhost.com' Owner='myid' Description='CF for Passthrough Pipeline.' \ 
+  --tags Name='marble-passthrough-pipeline' Contact='me@myhost.com' Owner='myid' Description='CF for Passthrough Pipeline.' \
   --parameter-overrides Receivers=email@email.com GitHubToken=ADDME! PassthroughVersion='setMe'
 ```
 

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -401,7 +401,7 @@ Resources:
           Name: Source
           Actions:
             -
-              Name: "RetrieveSourceCode"
+              Name: "AppCode"
               ActionTypeId:
                 Owner: ThirdParty
                 Category: Source
@@ -418,7 +418,7 @@ Resources:
           Name: Build
           Actions:
             -
-              Name: "BuildDockerImage"
+              Name: "Build"
               InputArtifacts:
                 - Name: SourceCode
               OutputArtifacts:
@@ -431,10 +431,10 @@ Resources:
               Configuration:
                 ProjectName: !Ref DockerCodePipelineBuilder
         -
-          Name: DeployToTest
+          Name: Test
           Actions:
             -
-              Name: "DeployAsTestTask"
+              Name: "Deploy"
               InputArtifacts:
                 - Name: BuiltCode
               ActionTypeId:
@@ -446,11 +446,8 @@ Resources:
                 ClusterName: !Sub '${InfrastructureStackName}-Cluster'
                 ServiceName: !Sub '${IIIFTestServiceStackName}-ImageService'
                 FileName: imagedefinitionstest.json
-        -
-          Name: Approval
-          Actions:
             -
-              Name: "RunQATests"
+              Name: "SmokeTest"
               InputArtifacts:
                 - Name: SourceCode
               ActionTypeId:
@@ -460,9 +457,9 @@ Resources:
                 Version: "1"
               Configuration:
                 ProjectName: !Ref DockerQABuilder
-              RunOrder: 1
+              RunOrder: 2
             -
-              Name: "ManualApprovalOfTestEnvironment"
+              Name: "Approval"
               ActionTypeId:
                 Owner: AWS
                 Category: Approval
@@ -471,12 +468,12 @@ Resources:
               Configuration:
                 NotificationArn: !Ref SNSTopic
                 CustomData: Approval or Reject this change after running Exploratory Tests
-              RunOrder: 2
+              RunOrder: 3
         -
-          Name: DeployToProduction
+          Name: Production
           Actions:
             -
-              Name: "DeployToProduction"
+              Name: "Deploy"
               InputArtifacts:
                 - Name: BuiltCode
               ActionTypeId:
@@ -489,7 +486,7 @@ Resources:
                 ServiceName: !Sub '${IIIFProdServiceStackName}-ImageService'
                 FileName: imagedefinitionsprod.json
         -
-          Name: PostDeployActions
+          Name: PostProduction
           Actions:
             -
               Name: "AddDockerTag"

--- a/deploy/cloudformation/manifest-passthrough-pipeline.yml
+++ b/deploy/cloudformation/manifest-passthrough-pipeline.yml
@@ -14,7 +14,7 @@ Parameters:
   ProdStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the production resources
-    Default: "marble-passthroughprimo-pipeline"
+    Default: "marble-passthroughprimo-pipeline-prod"
   TestStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the test resources
@@ -48,7 +48,7 @@ Parameters:
     Description: "Secret. OAuthToken with access to Repo. Long string of characters and digits. Go to https://github.com/settings/tokens"
   AppConfigPathProd:
     Type: String
-    Default: "/all/marble-passthroughprimo-pipeline"
+    Default: "/all/marble-passthroughprimo-pipeline-prod"
     Description: The path the keys for parameter store should be read and written to for config
   AppConfigPathTest:
     Type: String
@@ -126,6 +126,7 @@ Resources:
               - 'lambda:DeleteFunction'
               - 'lambda:CreateFunction'
               - 'lambda:TagResource'
+              - 'lambda:UpdateFunctionCode'
             Resource:
               - !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${TestStackName}-*'
               - !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${ProdStackName}-*'
@@ -322,7 +323,7 @@ Resources:
       Stages:
       - Name: Source
         Actions:
-        - Name: RetrieveAppCodeSource
+        - Name: AppCode
           InputArtifacts: []
           ActionTypeId:
             Version: "1"
@@ -339,7 +340,7 @@ Resources:
             PollForSourceChanges: true
           RunOrder: 1
         -
-          Name: "RetrieveConfigSource"
+          Name: "InfraCode"
           ActionTypeId:
             Owner: ThirdParty
             Category: Source
@@ -356,7 +357,7 @@ Resources:
           RunOrder: 1
       - Name: Build
         Actions:
-        - Name: BuildFromSource
+        - Name: Build
           InputArtifacts:
           - Name: AppCodeSource
           - Name: ConfigSource
@@ -372,7 +373,7 @@ Resources:
             PrimarySource: AppCodeSource
           RunOrder: 1
 
-      - Name: DeployToTest
+      - Name: Test
         Actions:
           - Name: CreateChangeSet
             ActionTypeId:
@@ -391,7 +392,7 @@ Resources:
               TemplateConfiguration: BuiltCode::test-stack-configuration.json
               TemplatePath: BuiltCode::output.yml
             RunOrder: 1
-          - Name: ExecuteChangeSet
+          - Name: Deploy
             ActionTypeId:
               Category: Deploy
               Owner: AWS
@@ -404,7 +405,7 @@ Resources:
               StackName: !Ref TestStackName
             RunOrder: 2
           -
-            Name: "ManualApprovalOfTestEnvironment"
+            Name: Approval
             ActionTypeId:
               Owner: AWS
               Category: Approval
@@ -415,7 +416,7 @@ Resources:
               CustomData: Approval or Reject this change after running Exploratory Tests
             RunOrder: 3
 
-      - Name: DeployToProduction
+      - Name: Production
         Actions:
           - Name: CreateChangeSet
             ActionTypeId:
@@ -434,7 +435,7 @@ Resources:
               TemplateConfiguration: BuiltCode::prod-stack-configuration.json
               TemplatePath: BuiltCode::output.yml
             RunOrder: 1
-          - Name: ExecuteChangeSet
+          - Name: Deploy
             ActionTypeId:
               Category: Deploy
               Owner: AWS

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -76,7 +76,7 @@ Parameters:
     Description: The name of the test IIIF image service stack
   ImageServiceProdStackName:
     Type: String
-    Default: "marble-image-service"
+    Default: "marble-image-service-prod"
     Description: The name of the production IIIF image service stack
   DataBrokerStackName:
     Type: String
@@ -84,7 +84,7 @@ Parameters:
     Description: The name of the shared data broker stack
   AppConfigPathProd:
     Type: String
-    Default: "/all/marble-manifest-pipeline"
+    Default: "/all/marble-manifest-pipeline-prod"
     Description: The path the keys for parameter store should be read and written to for config
   AppConfigPathTest:
     Type: String
@@ -434,7 +434,7 @@ Resources:
       Stages:
       - Name: Source
         Actions:
-        - Name: RetrieveAppCodeSource
+        - Name: AppCode
           InputArtifacts: []
           ActionTypeId:
             Version: "1"
@@ -451,7 +451,7 @@ Resources:
             PollForSourceChanges: true
           RunOrder: 1
         -
-          Name: "RetrieveConfigSource"
+          Name: "InfraCode"
           ActionTypeId:
             Owner: ThirdParty
             Category: Source
@@ -468,7 +468,7 @@ Resources:
           RunOrder: 1
       - Name: Build
         Actions:
-        - Name: BuildFromSource
+        - Name: Build
           InputArtifacts:
           - Name: AppCodeSource
           - Name: ConfigSource
@@ -484,7 +484,7 @@ Resources:
             PrimarySource: AppCodeSource
           RunOrder: 1
 
-      - Name: DeployToTest
+      - Name: Test
         Actions:
           - Name: CreateChangeSet
             ActionTypeId:
@@ -503,7 +503,7 @@ Resources:
               TemplateConfiguration: BuiltCode::test-stack-configuration.json
               TemplatePath: BuiltCode::output.yml
             RunOrder: 1
-          - Name: ExecuteChangeSet
+          - Name: Deploy
             ActionTypeId:
               Category: Deploy
               Owner: AWS
@@ -516,7 +516,7 @@ Resources:
               StackName: !Ref TestStackName
             RunOrder: 2
           -
-            Name: "ManualApprovalOfTestEnvironment"
+            Name: "Approval"
             ActionTypeId:
               Owner: AWS
               Category: Approval
@@ -527,7 +527,7 @@ Resources:
               CustomData: Approval or Reject this change after running Exploratory Tests
             RunOrder: 3
 
-      - Name: DeployToProduction
+      - Name: Production
         Actions:
           - Name: CreateChangeSet
             ActionTypeId:
@@ -546,7 +546,7 @@ Resources:
               TemplateConfiguration: BuiltCode::prod-stack-configuration.json
               TemplatePath: BuiltCode::output.yml
             RunOrder: 1
-          - Name: ExecuteChangeSet
+          - Name: Deploy
             ActionTypeId:
               Category: Deploy
               Owner: AWS

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -557,7 +557,7 @@ Resources:
           Name: Source
           Actions:
             -
-              Name: "RetrieveSourceCode"
+              Name: "AppCode"
               ActionTypeId:
                 Owner: ThirdParty
                 Category: Source
@@ -587,9 +587,9 @@ Resources:
               Configuration:
                 ProjectName: !Ref CodeBuilder
         -
-          Name: DeployToTest
+          Name: Test
           Actions:
-            - Name: "DeployToTest"
+            - Name: "Deploy"
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -602,11 +602,8 @@ Resources:
               Configuration:
                 ProjectName: !Ref CodeTestDeployer
               RunOrder: 1
-        -
-          Name: Approval
-          Actions:
             -
-              Name: "ManualApprovalOfTestEnvironment"
+              Name: "Approval"
               ActionTypeId:
                 Owner: AWS
                 Category: Approval
@@ -623,9 +620,9 @@ Resources:
                         Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'Hostname']]
 
         -
-          Name: DeployToProduction
+          Name: Production
           Actions:
-            - Name: "DeployToProduction"
+            - Name: "Deploy"
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -639,9 +636,9 @@ Resources:
                 ProjectName: !Ref CodeProdDeployer
               RunOrder: 1
         -
-          Name: PostDeployActions
+          Name: PostProduction
           Actions:
-            - Name: "UpdateGitHubStatus"
+            - Name: "AddGitHubStatus"
               ActionTypeId:
                 Category: Build
                 Owner: AWS


### PR DESCRIPTION
This changes all pipelines to ensure that any QA and Approval steps are grouped within the same stage as the Deploy to the test environment. This will prevent an integrity issue that can occur if multiple invocations of the pipeline happen before the Approver can visit the test site.
- Changed IIIF service deployment pipeline to group Deploy/QA/Approval into one stage.
- Changed static-host-pipeline to group the deploy/approval actions under a test stage

A few additional cleanups/fixes:
- Found a new reference to mellon in the README and changed to marble
- Changed default production stack names to include a -prod suffix to better match how we are now deploying these stacks
- Renamed several stages and actions to be more consistent across the different pipelines
- Fixed an issue with redeploying the lamba in manifest-passthrough-pipeline