### PR TITLE
Add better links to the approval messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ aws cloudformation deploy \
 ### IIIF Image Viewer Webcomponent stack
 ```console
 aws cloudformation deploy \
-  --stack-name marble-image-webcomponent-dev \
+  --stack-name marble-image-viewer-dev \
   --template-file deploy/cloudformation/static-host.yml \
-  --tags ProjectName=marble Name='testaccount-marbleimagewebcomponent-dev' \
+  --tags ProjectName=marble Name='testaccount-marbleimageviewer-dev' \
     Contact='me@myhost.com' Owner='myid' \
     Description='brief-description-of-purpose'
 ```
@@ -143,19 +143,19 @@ aws cloudformation deploy \
 ```
 
 ### IIIF Image Viewer Pipeline
-This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "marble-image-webcomponent-test" and "marble-image-webcomponent-prod".
+This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "marble-image-viewer-test" and "marble-image-viewer-prod".
 
 ```console
 aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
-  --stack-name marble-image-webcomponent-pipeline \
+  --stack-name marble-image-viewer-pipeline \
   --template-file deploy/cloudformation/static-host-pipeline.yml \
-  --tags ProjectName=marble Name='testaccount-marbleimagewebcomponentpipeline' \
+  --tags ProjectName=marble Name='testaccount-marbleimageviewerpipeline' \
     Contact='me@myhost.com' Owner='myid' \
     Description='brief-description-of-purpose' \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
-    SourceRepoOwner=ndlib SourceRepoName=image-viewer BuildScriptsDir='build' BuildOutputDir='dist' \
-    TestStackName=marble-image-webcomponent-test ProdStackName=marble-image-webcomponent-prod
+    SourceRepoOwner=ndlib SourceRepoName=marble-image-viewer BuildScriptsDir='build' BuildOutputDir='dist' \
+    TestStackName=marble-image-viewer-test ProdStackName=marble-image-viewer-prod
 ```
 
 # IIIF Manifest Pipeline
@@ -207,10 +207,10 @@ Note: The user must be logged in and have the appropriate permissions to approve
 ### Pipeline Monitoring
 Use this stack if you want to notify an email address of pipeline events. It is currently written to only accept a single email address, so it's recommended you use a mailing list for the Receivers parameter.
 
-Here's an example of adding monitoring to the image-webcomponent-pipeline
+Here's an example of adding monitoring to the image-viewer-pipeline
 ```console
 aws cloudformation deploy \
-  --stack-name marble-image-webcomponent-pipeline-monitoring \
+  --stack-name marble-image-viewer-pipeline-monitoring \
   --template-file deploy/cloudformation/pipeline-monitoring.yml \
   --tags ProjectName=marble Name='testaccount-marbleimagewebcomponentpipeline-monitoring' \
     Contact='me@myhost.com' Owner='myid' Description='brief-description-of-purpose' \

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -37,6 +37,16 @@ Parameters:
     Default: marble-image-service-test
     Description: The name of the CloudFormation stack that created the test ECS Service
 
+  TestImageServerHostname:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: The hostname of the IIIF Image Server
+    Default: '/all/stacks/marble-image-service-test/hostname'
+
+  ProdImageServerHostname:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: The hostname of the IIIF Image Server
+    Default: '/all/stacks/marble-image-service-prod/hostname'
+
   InfrastructureStackName:
     Type: String
     Default: marble-app-infrastructure
@@ -467,7 +477,7 @@ Resources:
                 Version: "1"
               Configuration:
                 NotificationArn: !Ref SNSTopic
-                CustomData: Approval or Reject this change after running Exploratory Tests
+                CustomData: !Sub "A new version of https://github.com/${SourceRepoOwner}/${SourceRepoName} has been deployed to https://${TestImageServerHostname}:8182 and is awaiting your approval. If you approve these changes, they will be deployed to https://${ProdImageServerHostname}:8182"
               RunOrder: 3
         -
           Name: Production

--- a/deploy/cloudformation/manifest-passthrough-pipeline.yml
+++ b/deploy/cloudformation/manifest-passthrough-pipeline.yml
@@ -249,7 +249,7 @@ Resources:
               commands:
                 - echo "Ensure that the codebuild directory is executable"
                 - chmod -R 755 ./scripts/codebuild/*
-                - export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_ConfigSource"
+                - export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_InfraCode"
                 - ./scripts/codebuild/install.sh
             pre_build:
               commands:
@@ -331,7 +331,7 @@ Resources:
             Owner: ThirdParty
             Provider: GitHub
           OutputArtifacts:
-          - Name: AppCodeSource
+          - Name: AppCode
           Configuration:
             Repo: !Ref PassthroughPrimoPipelineRepoName
             Branch: !Ref PassthroughPrimoPipelineRepoBranch
@@ -353,14 +353,14 @@ Resources:
             OAuthToken: !Ref GitHubToken
             PollForSourceChanges: false
           OutputArtifacts:
-            - Name: ConfigSource
+            - Name: InfraCode
           RunOrder: 1
       - Name: Build
         Actions:
         - Name: Build
           InputArtifacts:
-          - Name: AppCodeSource
-          - Name: ConfigSource
+          - Name: AppCode
+          - Name: InfraCode
           ActionTypeId:
             Category: Build
             Owner: AWS
@@ -370,7 +370,7 @@ Resources:
           - Name: BuiltCode
           Configuration:
             ProjectName: !Ref CodeBuildProject
-            PrimarySource: AppCodeSource
+            PrimarySource: AppCode
           RunOrder: 1
 
       - Name: Test
@@ -413,7 +413,7 @@ Resources:
               Version: "1"
             Configuration:
               NotificationArn: !Ref PipelineEventsTopic
-              CustomData: Approval or Reject this change after running Exploratory Tests
+              CustomData: !Sub "A new version of https://github.com/${GitHubUser}/${PassthroughPrimoPipelineRepoName} has been deployed to the ${TestStackName} stack and is awaiting your approval. If you approve these changes, they will be deployed to the ${ProdStackName} stack."
             RunOrder: 3
 
       - Name: Production

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -350,7 +350,7 @@ Resources:
               commands:
                 - echo "Ensure that the codebuild directory is executable"
                 - chmod -R 755 ./scripts/codebuild/*
-                - export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_ConfigSource"
+                - export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_InfraCode"
                 - ./scripts/codebuild/install.sh
             pre_build:
               commands:
@@ -442,7 +442,7 @@ Resources:
             Owner: ThirdParty
             Provider: GitHub
           OutputArtifacts:
-          - Name: AppCodeSource
+          - Name: AppCode
           Configuration:
             Repo: !Ref ManifestPipelineRepoName
             Branch: !Ref ManifestPipelineRepoBranch
@@ -464,14 +464,14 @@ Resources:
             OAuthToken: !Ref GitHubToken
             PollForSourceChanges: false
           OutputArtifacts:
-            - Name: ConfigSource
+            - Name: InfraCode
           RunOrder: 1
       - Name: Build
         Actions:
         - Name: Build
           InputArtifacts:
-          - Name: AppCodeSource
-          - Name: ConfigSource
+          - Name: AppCode
+          - Name: InfraCode
           ActionTypeId:
             Category: Build
             Owner: AWS
@@ -481,7 +481,7 @@ Resources:
           - Name: BuiltCode
           Configuration:
             ProjectName: !Ref CodeBuildProject
-            PrimarySource: AppCodeSource
+            PrimarySource: AppCode
           RunOrder: 1
 
       - Name: Test
@@ -524,7 +524,7 @@ Resources:
               Version: "1"
             Configuration:
               NotificationArn: !Ref PipelineEventsTopic
-              CustomData: Approval or Reject this change after running Exploratory Tests
+              CustomData: !Sub "A new version of https://github.com/${GitHubUser}/${ManifestPipelineRepoName} has been deployed to the ${TestStackName} stack and is awaiting your approval. If you approve these changes, they will be deployed to the ${ProdStackName} stack."
             RunOrder: 3
 
       - Name: Production

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -613,11 +613,12 @@ Resources:
                 NotificationArn: !Ref ApproversTopic
                 CustomData:
                   Fn::Sub:
-                    - "You can review these changes at https://${TestHostname}. Once approved, this will be deployed to https://${ProdHostname}."
+                    - "A new version of https://github.com/${SourceRepoOwner}/${SourceRepoName} has been deployed to https://${TestHostname} and is awaiting your approval. If you approve these changes, they will be deployed to https://${ProdHostname}."
                     - TestHostname:
                         Fn::ImportValue: !Join [':', [!Ref TestStackName, 'Hostname']]
                       ProdHostname:
                         Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'Hostname']]
+              RunOrder: 2
 
         -
           Name: Production


### PR DESCRIPTION
- Added parameter to the iiif-service-pipeline to retrieve the host names of the target stacks and added links to the repo and test/prod services in the approval message
- Added links to the repo and to the test/prod stacks in the approval message for the manifest services. These don't really have endpoints to review, so this is the best we can provide for now.
- Added links to the repo and to the test/prod stacks in the approval message for static host pipelines

Additional changes:

- Fixed a few naming problems in the readme associated with the image viewer
- The previous PR https://github.com/ndlib/marble-blueprints/pull/73 changed the source step names, but the artifact names that are passed around in the pipeline no longer matched those steps. Changed the artifact names to more closely match the source steps