### PR TITLE
SPA to Gatsby changes

### DIFF
--- a/deploy/cloudformation/unified-static-host.yml
+++ b/deploy/cloudformation/unified-static-host.yml
@@ -147,6 +147,10 @@ Resources:
               - '${HostnamePrefix}.${ResolvedDomainName}'
               - ResolvedDomainName:
                   Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /404.html
         DefaultRootObject: index.html
         DefaultCacheBehavior:
           ForwardedValues:

--- a/src/unifiedEdgeLambda/handler.js
+++ b/src/unifiedEdgeLambda/handler.js
@@ -7,6 +7,7 @@ exports.handler = (event, context, callback) => {
     // '.' in the last part of the URI is considered a sub path.
     var newuri = olduri.replace(/^.*\/([^.|^\/]+)$/, olduri + '/');
     // Append index.html to any request with a trailing slash
+    newuri = newuri.replace(/\/$/, '\/index.html');
     request.uri = newuri;
     return callback(null, request);
 }

--- a/src/unifiedEdgeLambda/handler.js
+++ b/src/unifiedEdgeLambda/handler.js
@@ -1,19 +1,12 @@
 'use strict';
-
-const pathMatches = new RegExp('^\/static|\/favicon.ico|\/robots.txt|\/sitemap.xml')
-
+// https://github.com/ndlib/esu-cloudformation/blob/master/lambda-edge-utils/default-directory-index.js
 exports.handler = (event, context, callback) => {
-  let request = event.Records[0].cf.request;
-
-  request.uri = exports.modifyRequestUri(request.uri)
-  callback(null, request)
-  return
-}
-
-exports.modifyRequestUri = (uri) => {
-  if (pathMatches.test(uri)) {
-    return uri
-  } else {
-    return "/index.html"
-  }
+    var request = event.Records[0].cf.request;
+    var olduri = request.uri;
+    // Add a trailing slash to a sub path if there is none. Anything without a
+    // '.' in the last part of the URI is considered a sub path.
+    var newuri = olduri.replace(/^.*\/([^.|^\/]+)$/, olduri + '/');
+    // Append index.html to any request with a trailing slash
+    request.uri = newuri;
+    return callback(null, request);
 }

--- a/src/unifiedEdgeLambda/handler.test.js
+++ b/src/unifiedEdgeLambda/handler.test.js
@@ -1,25 +1,53 @@
-const hander = require('./handler')
+// https://github.com/ndlib/esu-cloudformation/blob/master/lambda-edge-utils/default-directory-index.test.js
+const test_handler = require('./handler').handler
 
-test('it passes on the static directory', () => {
-  let tests = ['/static/index.js', '/static/js/2345235.chunk.js', '/static/js/main.246asgrt4.chunk.js']
+// Function to make it easier to create test event objects
+// to send to the test handler. Returns a cloudfront origin
+// event object with the given uri.
+describe('URL ReWrites', () => {
+  var new_test_event = (uri) => ({
+    Records: [
+      {
+        cf: {
+          response: {
+            status: 200,
+          },
+          request: {
+            uri: uri,
+          }
+        }
+      }
+    ]
+  })
 
-  for(let test of tests) {
-    expect(hander.modifyRequestUri(test)).toEqual(test)
-  }
-})
+  // Array of requested URIs and what we expect the function to rewrite it to
+  var test_uris = [
+    { test_uri: '', expected_uri: '' },
+    { test_uri: '/', expected_uri: '/index.html' },
+    { test_uri: '/sub_path', expected_uri: '/sub_path/index.html' },
+    { test_uri: '/sub_path/', expected_uri: '/sub_path/index.html' },
+    { test_uri: '/sub_path/sub_path', expected_uri: '/sub_path/sub_path/index.html' },
+    { test_uri: '/sub_path/sub_path/', expected_uri: '/sub_path/sub_path/index.html' },
+    { test_uri: '/page.html', expected_uri: '/page.html' },
+    // Note: this next one has implications for what we consider valid sub path names
+    // If this is unacceptable, we'll have to be a bit more precise with our regex
+    { test_uri: '/sub.path', expected_uri: '/sub.path' },
+  ]
 
-test("it allows the basic site files to be passed through", () => {
-  let tests = ['/favicon.ico', '/robots.txt', '/sitemap.xml', '/index.html']
-
-  for(let test of tests) {
-    expect(hander.modifyRequestUri(test)).toEqual(test)
-  }
-})
-
-test('other patterns are sent to the index.html', () => {
-  let tests = ['/', '', '/some_path', '/item/2342432', 'robots', '404', '/directory/subdir']
-
-  for(let test of tests) {
-    expect(hander.modifyRequestUri(test)).toEqual('/index.html')
-  }
+  // Loop through each of the test URIs and make sure the function under test rewrites
+  // the request correctly
+  test_uris.forEach((test_obj) => {
+    test('when URI "' + test_obj.test_uri + '" is requested, rewrites to: "' +test_obj.expected_uri + '"', () => {
+      var test_event = new_test_event(test_obj.test_uri)
+      // When AWS executes a Lambda, it passes in a callback function to your handler. It
+      // expects your handler to call the passed in function with the resultant data.
+      // This is a mock callback that we'll pass to the handler we are testing so that we can
+      // simulate what will happen when deployed. This mock function is where we inspect
+      // the data that the handler will ultimately be returned to Cloudfront.
+      const mock_callback = (err, data) => {
+        expect(data).toEqual({ uri : test_obj.expected_uri })
+      }
+      test_handler(test_event, null, mock_callback)
+    })
+  })
 })


### PR DESCRIPTION
These are changes to the Cloudfront configurations needed for the pipeline to deploy the Gatsby version of the Marble Website: https://github.com/ndlib/marble-website-starter

* Changes to the `src/unifiedEdgeLambda/handler.js` are copied from https://github.com/ndlib/esu-cloudformation/tree/master/lambda-edge-utils including tests.
* Added custom 404 page handling to `unified-static-host.yml`