### PR TITLE
Fix exports

### DIFF
--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -9,7 +9,7 @@ Description: >
   this file.
 
 
-Parameters:  
+Parameters:
   SourceRepoOwner:
     Type: String
     Description: The owner of the repository in Github
@@ -55,8 +55,14 @@ Outputs:
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PipelineName']]
 
+  ApprovalTopic:
+    Description: The manual approval SNS topic
+    Value: !Ref ApprovalTopic
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ApprovalTopic']]
+
 Resources:
-  ApproversTopic:
+  ApprovalTopic:
     Type: AWS::SNS::Topic
 
   CodeBuildRole:
@@ -599,7 +605,7 @@ Resources:
                 Provider: Manual
                 Version: "1"
               Configuration:
-                NotificationArn: !Ref ApproversTopic
+                NotificationArn: !Ref ApprovalTopic
                 CustomData:
                   Fn::Sub:
                     - "A new version of https://github.com/${SourceRepoOwner}/${SourceRepoName} has been deployed to https://${TestHostname} and is awaiting your approval. If you approve these changes, they will be deployed to https://${ProdHostname}."


### PR DESCRIPTION
Missed a pipeline change related to https://github.com/ndlib/marble-blueprints/pull/75. Changed static-host-pipeline.yml to export the approval topic to make it easier to bind monitoring and slack approvals