### PR TITLE
Change node version in static-host-pipeline

### DIFF
--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -143,6 +143,8 @@ Resources:
 
           phases:
             install:
+              runtime-versions:
+                nodejs: 10
               commands:
                 - echo Install started on `date`
                 - chmod -R 755 ${BuildScriptsDir}/*
@@ -170,7 +172,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/nodejs:10.1.0
+        Image: aws/codebuild/standard:2.0
         EnvironmentVariables:
           - Name: AWS_DEFAULT_REGION
             Value: !Ref AWS::Region


### PR DESCRIPTION
This bumps the build to use the latest nodejs. It also changes the CodeBuild to use the new polyglot way of defining the environment (https://aws.amazon.com/about-aws/whats-new/2019/07/aws-codebuild-adds-support-for-polyglot-builds/). I've tested this on both the website and image-viewer builds. Both seem to work, although image-viewer has a lot of warnings that did not exist in prior executions. We may need to either parameterize this in the future or update the image-viewer packages.