### PR TITLE
Fix task definition

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -156,7 +156,7 @@ Resources:
               - 'ecr:BatchGetImage'
               - 'ecr:CompleteLayerUpload'
               - 'ecr:PutImage'
-            Resource: 
+            Resource:
               - !Sub 'arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ImageProcessorContainerRepository}'
           - Effect: Allow
             Action:
@@ -737,7 +737,7 @@ Resources:
               ChangeSetName: TestChangeSetName
               TemplateConfiguration: BuiltCode::test-stack-configuration.json
               TemplatePath: BuiltCode::output.yml
-              ParameterOverrides: !Sub '{"ContainerImageUrl": "${ImageProcessorContainerRepository}:latest"}'
+              ParameterOverrides: !Sub '{"ContainerImageUrl": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ImageProcessorContainerRepository}:latest"}'
             RunOrder: 1
           - Name: Deploy
             ActionTypeId:
@@ -781,7 +781,7 @@ Resources:
               ChangeSetName: ProdChangeSetName
               TemplateConfiguration: BuiltCode::prod-stack-configuration.json
               TemplatePath: BuiltCode::output.yml
-              ParameterOverrides: !Sub '{"ContainerImageUrl": "${ImageProcessorContainerRepository}:latest"}'
+              ParameterOverrides: !Sub '{"ContainerImageUrl": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ImageProcessorContainerRepository}:latest"}'
             RunOrder: 1
           - Name: Deploy
             ActionTypeId:
@@ -886,7 +886,7 @@ Resources:
             Resource:
               - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${TestStackName}/*'
               - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${ProdStackName}/*'
-              
+
   DeploymentPermissions:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
The manifest CodePipeline wasn't pointing the task definition to the full URI of the ECR image that it built.