### PR TITLE
Fix Image Service access logs

### DIFF
--- a/deploy/cloudformation/app-infrastructure.yml
+++ b/deploy/cloudformation/app-infrastructure.yml
@@ -113,6 +113,19 @@ Resources:
           ExpirationInDays: 3653
           NoncurrentVersionExpirationInDays: 1
 
+  LogBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LogBucket
+      PolicyDocument:
+        Statement:
+          # Allow ALB access logs
+          - Action: 's3:PutObject'
+            Effect: 'Allow'
+            Resource: !Sub 'arn:aws:s3:::${LogBucket}/web/*/AWSLogs/${AWS::AccountId}/*'
+            Principal:
+              AWS: '127311923021' # us-east-1 ELB AccountId https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+
   SharedLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -222,7 +222,7 @@ Resources:
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         - Key: idle_timeout.timeout_seconds
-          Value: '30'
+          Value: '300'
       SecurityGroups:
         -
           Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'PublicLoadBalancerSecurityGroup']]


### PR DESCRIPTION
This is a hotfix to get the deployment to work. This adds a bucket policy to the shared log bucket to allow the ALB to write access logs. For now this will only work when the image service is deployed to us-east-1. This additionally extends the timeout between the ALB and Cantaloupe based on testing performed when rendering large images. This will likely need to be reassessed once we determine the sizes we will support.