### PR TITLE
Override create DNS record

### DIFF
--- a/deploy/cdk/bin/base.ts
+++ b/deploy/cdk/bin/base.ts
@@ -5,7 +5,17 @@ import 'source-map-support/register';
 import IIIF = require('../lib/iiif-serverless');
 
 const app = new App();
+
+const createDns : boolean = app.node.tryGetContext('createDns') === 'true' ? true : false;
+const domainStackName = app.node.tryGetContext('domainStackName');
+const oauthTokenPath = app.node.tryGetContext('oauthTokenPath');
+
 const imageServiceContext = app.node.tryGetContext('iiifImageService');
-new IIIF.DeploymentPipelineStack(app, 'marble-iiif-serverless-deployment', { ...imageServiceContext });
+new IIIF.DeploymentPipelineStack(app, 'marble-image-service-deployment', {
+  createDns,
+  domainStackName,
+  oauthTokenPath,
+  ...imageServiceContext
+});
 
 app.node.applyAspect(new StackTags());

--- a/deploy/cdk/cdk.json
+++ b/deploy/cdk/cdk.json
@@ -1,21 +1,19 @@
 {
   "app": "npx ts-node bin/base.ts",
   "context": {
+    "createDns": "true",
+    "domainStackName": "marble-domain",
+    "oauthTokenPath": "/all/github/ndlib-git",
     "iiifImageService": {
-      "oauthTokenPath": "/all/github/ndlib-git",
       "imageSourceBucketPath": "/all/stacks/marble-data-broker/publicbucket",
-      "stackPrefix": "marble-iiif-serverless",
-      "domainStackName": "marble-domain",
-      "hostnamePrefix": "image-iiif-serverless",
-
+      "stackPrefix": "marble-image-service",
+      "hostnamePrefix": "image-iiif",
       "appRepoOwner": "ndlib",
       "appRepoName": "serverless-iiif",
       "appSourceBranch": "master", 
-
       "infraRepoOwner": "ndlib",
       "infraRepoName": "marble-blueprints",
       "infraSourceBranch": "master", 
-
       "qaRepoOwner": "ndlib",
       "qaRepoName": "iiif-qa",
       "qaSourceBranch": "master"

--- a/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
+++ b/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
@@ -28,6 +28,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly domainStackName: string;
   readonly domainCertificateArn: string;
   readonly hostnamePrefix: string;
+  readonly createDns: boolean;
 };
 
 export class DeploymentPipelineStack extends cdk.Stack {
@@ -148,6 +149,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         DomainStackName: props.domainStackName,
         APIStackName: testStackName,
         DomainCertificateArn: props.domainCertificateArn,
+        CreateDNSRecord: props.createDns ? 'True' : 'False',
       },
       capabilities: [
         CloudFormationCapabilities.AUTO_EXPAND,
@@ -216,6 +218,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         DomainStackName: props.domainStackName,
         APIStackName: prodStackName,
         DomainCertificateArn: props.domainCertificateArn,
+        CreateDNSRecord: props.createDns ? 'True' : 'False',
       },
       capabilities: [
         CloudFormationCapabilities.AUTO_EXPAND,


### PR DESCRIPTION
Need a way to ensure this does not create DNS in our production account. Had to add some top level context entries so that we can more easily override these with `-c` on the cli when deploying within CodeBuild. Also renamed the stacks to match what we previously did for the IIIF service