### PR TITLE
Fix reliance on Zone from domain stack

### DIFF
--- a/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
+++ b/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
@@ -37,7 +37,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
 
     const appRepoUrl = `https://github.com/${props.appRepoOwner}/${props.appRepoName}`;
     const resolvedDomain = Fn.importValue(`${props.domainStackName}:DomainName`);
-    const hostedZone = Fn.importValue(`${props.domainStackName}:Zone`);
     const testHost = `${props.hostnamePrefix}-test.${resolvedDomain}`;
     const testStackName = `${props.stackPrefix}-test`;
     const testCDNStackName = `${props.stackPrefix}-cdn-test`;
@@ -294,7 +293,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
     deployTestAction.addToDeploymentRolePolicy(NamespacedPolicy.api());
 
     deployTestCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.ssm(testCDNStackName));
-    deployTestCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.route53RecordSet(hostedZone));
     deployTestCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.apiDomain(testHost));
     deployTestCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.globals([GlobalActions.Cloudfront, GlobalActions.Route53]));
 
@@ -315,8 +313,13 @@ export class DeploymentPipelineStack extends cdk.Stack {
     deployProdAction.addToDeploymentRolePolicy(NamespacedPolicy.api());
 
     deployProdCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.ssm(prodCDNStackName));
-    deployProdCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.route53RecordSet(hostedZone));
     deployProdCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.apiDomain(prodHost));
     deployProdCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.globals([GlobalActions.Cloudfront, GlobalActions.Route53]));
+
+    if(props.createDns){
+      const hostedZone = Fn.importValue(`${props.domainStackName}:Zone`);
+      deployTestCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.route53RecordSet(hostedZone));
+      deployProdCDNAction.addToDeploymentRolePolicy(NamespacedPolicy.route53RecordSet(hostedZone));
+    }
   }
 }


### PR DESCRIPTION
Changed deployment pipeline to not import the Route53 zone from the domain stack when not creating a DNS recordset, since in this context the domain stack probably doesn't manage a zone.