### PR TITLE
Add commit info to approvals

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -662,6 +662,7 @@ Resources:
       - Name: Source
         Actions:
         - Name: AppCode
+          Namespace: "AppCodeVars"
           InputArtifacts: []
           ActionTypeId:
             Version: "1"
@@ -766,7 +767,7 @@ Resources:
               Version: "1"
             Configuration:
               NotificationArn: !Ref ApprovalTopic
-              CustomData: !Sub "A new version of https://github.com/${GitHubUser}/${ManifestPipelineRepoName} has been deployed to the ${TestStackName} stack and is awaiting your approval. If you approve these changes, they will be deployed to the ${ProdStackName} stack."
+              CustomData: !Sub "A new version of https://github.com/${GitHubUser}/${ManifestPipelineRepoName}/tree/#{AppCodeVars.BranchName} has been deployed to the ${TestStackName} stack and is awaiting your approval. If you approve these changes, they will be deployed to the ${ProdStackName} stack.\n\n*Commit Message*\n#{AppCodeVars.CommitMessage}\n\nFor more details on the changes, see https://github.com/${GitHubUser}/#{AppCodeVars.RepositoryName}/commit/#{AppCodeVars.CommitId}."
             RunOrder: 3
 
       - Name: Production

--- a/deploy/cloudformation/primo-passthrough-pipeline.yml
+++ b/deploy/cloudformation/primo-passthrough-pipeline.yml
@@ -334,6 +334,7 @@ Resources:
       - Name: Source
         Actions:
         - Name: AppCode
+          Namespace: "AppCodeVars"
           InputArtifacts: []
           ActionTypeId:
             Version: "1"
@@ -423,7 +424,7 @@ Resources:
               Version: "1"
             Configuration:
               NotificationArn: !Ref ApprovalTopic
-              CustomData: !Sub "A new version of https://github.com/${GitHubUser}/${PassthroughPrimoPipelineRepoName} has been deployed to the ${TestStackName} stack and is awaiting your approval. If you approve these changes, they will be deployed to the ${ProdStackName} stack."
+              CustomData: !Sub "A new version of https://github.com/${GitHubUser}/${PassthroughPrimoPipelineRepoName}/tree/#{AppCodeVars.BranchName} has been deployed to the ${TestStackName} stack and is awaiting your approval. If you approve these changes, they will be deployed to the ${ProdStackName} stack.\n\n*Commit Message*\n#{AppCodeVars.CommitMessage}\n\nFor more details on the changes, see https://github.com/${GitHubUser}/#{AppCodeVars.RepositoryName}/commit/#{AppCodeVars.CommitId}."
             RunOrder: 3
 
       - Name: Production
@@ -522,7 +523,7 @@ Resources:
             Resource:
               - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${TestStackName}/*'
               - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${ProdStackName}/*'
-              
+
   DeploymentPermissions:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -561,6 +561,7 @@ Resources:
           Actions:
             -
               Name: "AppCode"
+              Namespace: "AppCodeVars"
               ActionTypeId:
                 Owner: ThirdParty
                 Category: Source
@@ -616,7 +617,7 @@ Resources:
                 NotificationArn: !Ref ApprovalTopic
                 CustomData:
                   Fn::Sub:
-                    - "A new version of https://github.com/${SourceRepoOwner}/${SourceRepoName} has been deployed to https://${TestHostname} and is awaiting your approval. If you approve these changes, they will be deployed to https://${ProdHostname}."
+                    - "A new version of https://github.com/${SourceRepoOwner}/${SourceRepoName}/tree/#{AppCodeVars.BranchName} has been deployed to https://${TestHostname} and is awaiting your approval. If you approve these changes, they will be deployed to https://${ProdHostname}.\n\n*Commit Message*\n#{AppCodeVars.CommitMessage}\n\nFor more details on the changes, see https://github.com/${SourceRepoOwner}/#{AppCodeVars.RepositoryName}/commit/#{AppCodeVars.CommitId}."
                     - TestHostname:
                         Fn::ImportValue: !Join [':', [!Ref TestStackName, 'Hostname']]
                       ProdHostname:


### PR DESCRIPTION
Added commit message and a url to the changes to the approval message in all pipelines based on cloudformation. We'll have to wait a bit until cdk supports the namespace property of actions (https://github.com/aws/aws-cdk/issues/5219) before we can change those.

Reference: https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-variables.html#reference-variables-list