### PR TITLE
MARBLE-678 Change Unique Identifier for Users

### DIFF
--- a/deploy/cdk/lib/user-content/index.ts
+++ b/deploy/cdk/lib/user-content/index.ts
@@ -19,10 +19,17 @@ export class UserContentStack extends cdk.Stack {
     const userDynamoTable = new dynamodb.Table(this, 'UsersTable', {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: {
-        name: 'userName',
+        name: 'uuid',
         type: dynamodb.AttributeType.STRING
       },
       tableName: `${this.stackName}-users`,
+    });
+    userDynamoTable.addGlobalSecondaryIndex({
+      indexName: 'userName',
+      partitionKey: {
+        name: 'userName',
+        type: dynamodb.AttributeType.STRING
+      }
     });
 
     const collectionDynamoTable = new dynamodb.Table(this, 'CollectionsTable', {
@@ -34,9 +41,9 @@ export class UserContentStack extends cdk.Stack {
       tableName: `${this.stackName}-collections`,
     });
     collectionDynamoTable.addGlobalSecondaryIndex({
-      indexName: 'userName',
+      indexName: 'userId',
       partitionKey: {
-        name: 'userName',
+        name: 'userId',
         type: dynamodb.AttributeType.STRING
       }
     });
@@ -50,9 +57,9 @@ export class UserContentStack extends cdk.Stack {
       tableName: `${this.stackName}-items`,
     });
     itemDynamoTable.addGlobalSecondaryIndex({
-      indexName: 'collection',
+      indexName: 'collectionId',
       partitionKey: {
-        name: 'collection',
+        name: 'collectionId',
         type: dynamodb.AttributeType.STRING
       }
     });
@@ -65,16 +72,16 @@ export class UserContentStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_10_X,
       environment: {
         USER_TABLE_NAME: userDynamoTable.tableName,
-        USER_PRIMARY_KEY: 'userName',
+        USER_PRIMARY_KEY: 'uuid',
+        USER_SECONDARY_KEY: 'userName',
         COLLECTION_TABLE_NAME: collectionDynamoTable.tableName,
         COLLECTION_PRIMARY_KEY: 'uuid',
-        COLLECTION_SECONDARY_KEY: 'userName',
+        COLLECTION_SECONDARY_KEY: 'userId',
         ITEM_TABLE_NAME: itemDynamoTable.tableName,
         ITEM_PRIMARY_KEY: 'uuid',
-        ITEM_SECONDARDY_KEY: 'collection',
+        ITEM_SECONDARDY_KEY: 'collectionId',
         TOKEN_ISSUER: ssm.StringParameter.fromStringParameterName(this, 'TokenIssuer', props.tokenIssuerPath).stringValue,
         TOKEN_AUDIENCE: ssm.StringParameter.fromStringParameterName(this, 'Audience', props.tokenAudiencePath).stringValue,
-        USERNAME_CLAIM: 'netid'
       }
     });
 
@@ -102,6 +109,10 @@ export class UserContentStack extends cdk.Stack {
     userId.addMethod('GET', userContentIntegration);
     userId.addMethod('PATCH', userContentIntegration);
     userId.addMethod('DELETE', userContentIntegration);
+
+    const userByUuid = api.root.addResource('user-id');
+    const userByUuidId = userByUuid.addResource('{id}')
+    userByUuidId.addMethod('GET', userContentIntegration);
 
     // collection endpoints
     const collection = api.root.addResource('collection');


### PR DESCRIPTION
* Previously the unique identifier for users was the user `netid`. This  would become problematic when we implement alternative login methods such as Facebook or Google later on. 
* To remedy this the unique identifier will be changed to a hash value of the `sub` and `iss` fields on the user token. 
* Most of the needed change will take place in the Marble User Content lambda code, but we need an additional `GET` endpoint for the API and an additional secondary global index on the user table to continue being able to look up users by `userName`.

The associated Lambda changes are here: https://github.com/ndlib/marble-user-content/pull/5