### PR TITLE
Add pipeline email notifications and cors header

### DIFF
--- a/deploy/cdk/bin/base.ts
+++ b/deploy/cdk/bin/base.ts
@@ -35,6 +35,7 @@ const userContentContext = {
   infraRepoOwner: app.node.tryGetContext('userContent:infraRepoOwner'),
   infraRepoName: app.node.tryGetContext('userContent:infraRepoName'),
   infraSourceBranch: app.node.tryGetContext('userContent:infraSourceBranch'),
+  notificationReceivers: app.node.tryGetContext('userContent:deployNotificationReceivers'),
 };
 new userContent.UserContentStack(app, `${namespace}-user-content`, userContentContext);
 new userContent.DeploymentPipelineStack(app, `${namespace}-user-content-deployment`, {

--- a/deploy/cdk/lib/user-content/deployment-pipeline.ts
+++ b/deploy/cdk/lib/user-content/deployment-pipeline.ts
@@ -6,7 +6,7 @@ import { PolicyStatement } from '@aws-cdk/aws-iam';
 import { Bucket, BucketEncryption } from '@aws-cdk/aws-s3';
 import { Topic } from '@aws-cdk/aws-sns';
 import cdk = require('@aws-cdk/core');
-import { SlackApproval } from '@ndlib/ndlib-cdk';
+import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk';
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy';
 import { NamespacedPolicy } from '../namespaced-policy';
 import { Artifact } from '@aws-cdk/aws-codepipeline';
@@ -25,6 +25,8 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly tokenAudiencePath: string;
   readonly tokenIssuerPath: string;
   readonly slackNotifyStackName?: string;
+  readonly allowedOrigins: string;
+  readonly notificationReceivers?: string;
 };
 
 export class DeploymentPipelineStack extends cdk.Stack {
@@ -54,6 +56,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           owner: props.owner,
           contact: props.contact,
           "userContent:lambdaCodePath": "$CODEBUILD_SRC_DIR_AppCode/src",
+          "userContent:allowedOrigins": props.allowedOrigins,
         },
         postDeployCommands: [
           // This API isn't using DNS, and the endpoint isn't created until the deploy command completes,
@@ -205,5 +208,11 @@ export class DeploymentPipelineStack extends cdk.Stack {
         }
       ],
     });
+    if(props.notificationReceivers){
+      const notifications = new PipelineNotifications(this, 'PipelineNotifications', {
+        pipeline,
+        receivers: props.notificationReceivers,
+      });
+    }
   }
 }

--- a/docs/user-content.md
+++ b/docs/user-content.md
@@ -26,3 +26,7 @@ cdk deploy [NAMESPACE]-user-content-deployment \
   -c "userContent:infraSourceBranch"="master" \
   -c "userContent:appSourceBranch"="master"
 ```
+
+If you're using our [Slack approval bot](https://github.com/ndlib/codepipeline-approvals/blob/master/slack_approval.md), you can associate this pipeline to a channel notifier with an optional context parameter `-c slackNotifyStackName=slack-approval-bot-marble-notifier`
+
+If you want to receive email notifications any time the pipeline state changes, specify an additional context paramter `-c "userContent:deployNotificationReceivers=me@myhost.com"`


### PR DESCRIPTION
Pipeline can now add an optional email notification anytime state
changes. Also fixed an issue with propagating cors headers down to the
deployed stacks.