### PR TITLE
changes related to rbsc-image-bucket

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -96,14 +96,10 @@ Parameters:
   SentryDsn:
     Type: String
     Description: The sentry data source name(DSN)
-  RBSCS3ProdImageBucketArn:
+  RBSCS3ImageBucketName:
     Type: String
-    Default: "arn:aws:s3:::libnd-smb-rbsc"
-    Description: "The bucjet that rarebooks images are in for the search process"
-  RBSCS3TestImageBucketArn:
-    Type: String
-    Default: "arn:aws:s3:::libnd-smb-rbsc"
-    Description: "The bucjet that rarebooks images are in for the search process"
+    Description: "The name of the bucket that rarebooks images are in for the search process"
+    Default: "libnd-smb-rbsc"
 
 
 Outputs:
@@ -482,7 +478,7 @@ Resources:
                         \"CreateDNSRecord\" : \"${CreateDNSRecord}\",
                         \"InfrastructureStackName\" : \"${InfrastructureStackName}\",
                         \"SentryDsn\" : \"${SentryDsn}\",
-                        \"RBSCS3ImageBucketArn\" : \"${RBSCS3TestImageBucketArn}\"
+                        \"RBSCS3ImageBucketName\" : \"${RBSCS3ImageBucketName}\"
                       },
                       \"Tags\" : {
                         \"Name\" : \"${TestStackName}\",
@@ -502,7 +498,7 @@ Resources:
                         \"CreateDNSRecord\" : \"${CreateDNSRecord}\",
                         \"InfrastructureStackName\" : \"${InfrastructureStackName}\",
                         \"SentryDsn\" : \"${SentryDsn}\",
-                        \"RBSCS3ImageBucketArn\" : \"${RBSCS3ProdImageBucketArn}\"
+                        \"RBSCS3ImageBucketName\" : \"${RBSCS3ImageBucketName}\"
                       },
                       \"Tags\" : {
                         \"Name\" : \"${ProdStackName}\",

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -48,9 +48,9 @@ Parameters:
   SentryDsn:
     Type: String
     Description: The sentry data source name(DSN)
-  RBSCS3ImageBucketArn:
+  RBSCS3ImageBucketName:
     Type: String
-    Description: "The bucket that rarebooks images are in for the search process"
+    Description: "The name of the bucket that rarebooks images are in for the search process"
   GoogleKeyPath:
     Type: String
     Description: The ssm path to look for the google team drive credentials and drive-id
@@ -161,6 +161,14 @@ Resources:
       Name: !Sub "${AppConfigPath}/process-bucket"
       Value: !Ref ProcessBucket
       Description: Manifest Server URL
+
+  SSMRBSCS3ImageBucketName:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Name: !Sub "${AppConfigPath}/rbsc-image-bucket"
+      Value: !Ref RBSCS3ImageBucketName
+      Description: Name of RBSC Image Bucket
 
   ProcessBucket:
     Type: AWS::S3::Bucket
@@ -545,8 +553,8 @@ Resources:
                   - "s3:ListBucket"
                 Effect: "Allow"
                 Resource:
-                  - !Ref RBSCS3ImageBucketArn
-                  - !Sub "${RBSCS3ImageBucketArn}/*"
+                  - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}"
+                  - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}/*"
         - PolicyName: GDriveSsmPermissions
           PolicyDocument:
             Version: 2012-10-17
@@ -823,8 +831,8 @@ Resources:
                 - 's3:ListObjects'
                 - 's3:ListBucket'
               Resource:
-                - !Ref RBSCS3ImageBucketArn
-                - !Sub "${RBSCS3ImageBucketArn}/*"
+                - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}"
+                - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}/*"
         - Version: 2012-10-17
           Statement:
             - Effect: Allow
@@ -909,8 +917,8 @@ Resources:
                 - 's3:ListObjects'
                 - 's3:ListBucket'
               Resource:
-                - !Ref RBSCS3ImageBucketArn
-                - !Sub "${RBSCS3ImageBucketArn}/*"
+                - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}"
+                - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}/*"
         - Version: 2012-10-17
           Statement:
             - Effect: Allow


### PR DESCRIPTION
Replaced references to RBSCS3ProdImageBucketArn and RBSCS3TestImageBucketArn with RBSCS3ImageBucketName

Need to change deploy parameters from passing:
  RBSCS3ProdImageBucketArn=arn:aws:s3:::libnd-smb-rbsc \
  RBSCS3TestImageBucketArn=arn:aws:s3:::libnd-smb-rbsc

To passing:
  RBSCS3ImageBucketName=libnd-smb-rbsc
