### PR TITLE
Update handler.js to include .webp as a valid format

### DIFF
--- a/src/unifiedEdgeLambda/handler.js
+++ b/src/unifiedEdgeLambda/handler.js
@@ -10,7 +10,7 @@ exports.handler = (event, context, callback) => {
 
   // this is not the best way that this we may need to do an s3 head request to fully
   // detect if the file exists.
-  let valid_extensions = ['.html', '.js', '.json', '.css', '.jpg', '.jpeg', '.png', '.ico', '.map', '.txt', '.kml', '.svg', '.webmanifest', '.xml', '.zip']
+  let valid_extensions = ['.html', '.js', '.json', '.css', '.jpg', '.jpeg', '.png', '.ico', '.map', '.txt', '.kml', '.svg', '.webmanifest', '.webp', '.xml', '.zip']
   // if there is no extension or it is not in one of the extensions we expect to find on the
   // server.
   if (parsedPath.ext == '' || !valid_extensions.includes(parsedPath.ext)) {


### PR DESCRIPTION
`webp` is a "next generation" image format. SEO tools like to see it instead of older formats.