### PR TITLE
this is what i think is wrong in the pipeline

### DIFF
--- a/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
+++ b/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
@@ -45,8 +45,8 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const prodCDNStackName = `${props.namespace}-image-service-cdn-prod`;
     const sourceBucketParam = ssm.StringParameter.fromStringParameterName(this, 'SourceBucket', props.imageSourceBucketPath);
 
-    const artifactBucket = new Bucket(this, 'artifactBucket', { 
-      encryption: BucketEncryption.KMS_MANAGED, 
+    const artifactBucket = new Bucket(this, 'artifactBucket', {
+      encryption: BucketEncryption.KMS_MANAGED,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
@@ -102,7 +102,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           },
         },
         version: '0.2',
-        artifacts: { 
+        artifacts: {
           files: ['package_output.yml']
         }
       }),
@@ -117,7 +117,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
     }));
     const buildAction = new codepipelineActions.CodeBuildAction({
       actionName: 'Build',
-      input: appSourceArtifact, 
+      input: appSourceArtifact,
       outputs: [builtCodeArtifact],
       project: build,
     });
@@ -178,7 +178,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
       },
     });
     const smokeTestsAction = new codepipelineActions.CodeBuildAction({
-      input: qaSourceArtifact, 
+      input: qaSourceArtifact,
       project: smokeTestsProject,
       actionName: 'SmokeTests',
       runOrder: 98,
@@ -199,7 +199,8 @@ export class DeploymentPipelineStack extends cdk.Stack {
       stackName: prodStackName,
       adminPermissions: false,
       parameterOverrides: {
-        SourceBucket: sourceBucketParam.stringValue
+        SourceBucket: sourceBucketParam.stringValue,
+        IiifLambdaTimeout: 20
       },
       capabilities: [
         CloudFormationCapabilities.AUTO_EXPAND,
@@ -247,7 +248,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
       },
     });
     const smokeTestsProdAction = new codepipelineActions.CodeBuildAction({
-      input: qaSourceArtifact, 
+      input: qaSourceArtifact,
       project: smokeTestsProdProject,
       actionName: 'SmokeTests',
       runOrder: 98,

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -715,6 +715,8 @@ Resources:
               Name: "Build"
               InputArtifacts:
                 - Name: SourceCode
+              OutputArtifacts:
+                - Name: ProdBuiltCode
               ActionTypeId:
                 Owner: AWS
                 Category: Build
@@ -730,7 +732,7 @@ Resources:
                 Version: '1'
                 Provider: CodeBuild
               InputArtifacts:
-              - Name: BuiltCode
+              - Name: ProdBuiltCode
               OutputArtifacts:
               - Name: ProdDeployOutput
               Configuration:


### PR DESCRIPTION
The problem. 

We are deploying the test artifacts built for test to prod and it seems like it is causing us to point at the test instance of elastic search.  no matter how hard we try to fix it... 

This creates a new output artifact similar to what the test build does.  
Then it uses that in the deploy instead of the name of the output artifacts from the test build. 

