### PR TITLE
temporarily removed logging from StateMachineCreateCSVs

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -1050,15 +1050,15 @@ Resources:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
       StateMachineName: !Sub "${AWS::StackName}-StateMachineCreateCSVs"
-      LoggingConfiguration:
-        Destinations:
-          - CloudWatchLogsLogGroup:
-              LogGroupArn: !Sub
-                - "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${FindLogGroup}:*"
-                - FindLogGroup:
-                    Fn::ImportValue: !Sub "${InfrastructureStackName}:LogGroup"
-        IncludeExecutionData: true
-        Level: ALL
+      # LoggingConfiguration:
+      #   Destinations:
+      #     - CloudWatchLogsLogGroup:
+      #         LogGroupArn: !Sub
+      #           - "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${FindLogGroup}:*"
+      #           - FindLogGroup:
+      #               Fn::ImportValue: !Sub "${InfrastructureStackName}:LogGroup"
+      #   IncludeExecutionData: true
+      #   Level: ALL
       DefinitionString:
         !Sub
           - |-


### PR DESCRIPTION
I'm leaving the role definition in tact in AllowStepFunctionLoggingPolicy.

Removed logging from StateMachineCreateCSVs to try to get this to run the pipeline deploy in production.  Then will come back and re-add.
