### PR TITLE
update permissions with missing resource

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -396,11 +396,12 @@ Resources:
                 - "s3:GetObject"
                 - "s3:PutObject"
                 - "s3:PutObjectVersionAcl"
-                - "s3:PutObjectAcl"                       
+                - "s3:PutObjectAcl"
                 - "s3:ListBucket"
                 - "s3:ListBucketVersions"
               Resource:
                 - !GetAtt ProcessBucket.Arn
+                - !Join ["", [!GetAtt ProcessBucket.Arn, "/*"]]
       Runtime: python3.7
       Timeout: 90
       CodeUri: init/


### PR DESCRIPTION
When I copied the permissions for putting I forgot the second version of the resource needed for s3.  