### PR TITLE
Added ArchivesSpaceExportLambdaFunction

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -1054,6 +1054,53 @@ Resources:
           STATE_MACHINE: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-StateMachineCreateCSVs"
 
 
+  ArchivesSpaceExportLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler.run
+      Runtime: python3.7
+      Timeout: 900
+      CodeUri: archivesspace_export/
+      Policies:
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - 's3:ListObjects'
+                - 's3:ListBucket'
+              Resource:
+                - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}"
+                - !Sub "arn:aws:s3:::${RBSCS3ImageBucketName}/*"
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - 'states:ListStateMachines'
+                - 'states:StartExecution'
+              Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-StateMachineCreateCSVs"
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - "ssm:GetParametersByPath"
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AppConfigPath}/*"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MarbleProcessingKeyPath}/*"
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - "s3:PutObject"
+                - 's3:GetObject'
+              Resource:
+                - !Join ["", [!GetAtt ProcessBucket.Arn, "/*"]]
+      Environment:
+        Variables:
+          SSM_KEY_BASE: !Ref AppConfigPath
+          SENTRY_DSN: !Ref SentryDsn
+          STATE_MACHINE: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-StateMachineCreateCSVs"
+
+
   StateMachineCreateCSVs:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:
@@ -1071,9 +1118,46 @@ Resources:
         !Sub
           - |-
             {
-              "Comment": "Create CSVs of ArchivesSpace EAD metadata and image info",
-              "StartAt": "MuseumExportTask",
+              "Comment": "Create nd.json of metadata and image info from various source systems.",
+              "StartAt": "ArchivesSpaceExportTask",
               "States": {
+                "ArchivesSpaceExportTask": {
+                  "Type": "Task",
+                  "Resource": "${archivesSpaceExportLambdaArn}",
+                  "Catch": [
+                    {
+                      "ErrorEquals": [ "Lambda.Unknown" ],
+                      "ResultPath": "$.unexpected",
+                      "Next": "MuseumExportTask"
+                    },
+                    {
+                      "ErrorEquals": [ "States.TaskFailed" ],
+                      "ResultPath": "$.unexpected",
+                      "Next": "MuseumExportTask"
+                    },
+                    {
+                      "ErrorEquals": [ "States.ALL" ],
+                      "ResultPath": "$.unexpected",
+                      "Next": "MuseumExportTask"
+                    }
+                  ],
+                  "Next": "ArchivesSpaceLoopChoice"
+                },
+                "ArchivesSpaceLoopChoice": {
+                  "Type": "Choice",
+                  "Choices": [
+                    {
+                      "Variable": "$.archivesSpaceHarvestComplete",
+                      "BooleanEquals": false,
+                      "Next": "ArchivesSpaceExportTask"
+                    },
+                    {
+                      "Variable": "$.archivesSpaceHarvestComplete",
+                      "BooleanEquals": true,
+                      "Next": "MuseumExportTask"
+                    }
+                  ]
+                },
                 "MuseumExportTask": {
                   "Type": "Task",
                   "Resource": "${museumExportLambdaArn}",
@@ -1206,6 +1290,7 @@ Resources:
               museumExportLambdaArn:  !GetAtt [MuseumExportLambdaFunction, Arn],
               alephExportLambdaArn:  !GetAtt [AlephExportLambdaFunction, Arn],
               curateExportLambdaArn:  !GetAtt [CurateExportLambdaFunction, Arn],
+              archivesSpaceExportLambdaArn:  !GetAtt [ArchivesSpaceExportLambdaFunction, Arn],
             }
       RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
 


### PR DESCRIPTION
Added ArchivesSpaceExportLambdaFunction

Added call to this lambda to StateMachineCreateCSVs.

Note:  This lambda creates nd.json for  ArchivesSpace content, regardless of the existance of a DOA record.  After manifest creation is changed to use nd.json, we can remove HarvestEADsLambdaFunction.