### PR TITLE
Let museum_export list, read, and delete file on process bucket

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -965,7 +965,9 @@ Resources:
                 - "s3:DeleteObject"
                 - "s3:ListBucket"
               Resource:
+                - !GetAtt ProcessBucket.Arn
                 - !Join ["", [!GetAtt ProcessBucket.Arn, "/*"]]
+
       Environment:
         Variables:
           SSM_KEY_BASE: !Ref AppConfigPath

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -960,7 +960,10 @@ Resources:
           Statement:
             - Effect: Allow
               Action:
+                - "s3:GetObject"
                 - "s3:PutObject"
+                - "s3:DeleteObject"
+                - "s3:ListBucket"
               Resource:
                 - !Join ["", [!GetAtt ProcessBucket.Arn, "/*"]]
       Environment:


### PR DESCRIPTION
* Added permissions for museum_export lambda to list, read, and delete files on process bucket so it can loop between iterations and retain state.