### PR TITLE
Fix manifest-pipeline deploy failure

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -360,8 +360,10 @@ Resources:
               - "events:PutTargets"
               - "events:PutRule"
               - "events:DescribeRule"
+              - "events:RemoveTargets"
             Resource:
               - !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/${ProdStackName}-StartHarvestAndCreateCSVRule*"
+              - !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/${ProdStackName}-StartHarvestAndCreateStandardJsonRule*"
               - !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/${ProdStackName}-StartManifestPipelineRule*"
             Effect: Allow
       Roles:

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -93,7 +93,7 @@ Parameters:
 
 Conditions:
   CreateDNS: !Equals [ !Ref CreateDNSRecord, 'True' ]
-  CreateHarvestAndCSVRule: !Equals [ !Ref CreateHarvestRule, 'True' ]
+  CreateHarvestAndStdJsonCondition: !Equals [ !Ref CreateHarvestRule, 'True' ]
 
 Outputs:
   SchemaStateMachine:
@@ -626,7 +626,6 @@ Resources:
                   - "events:PutTargets"
                   - "events:PutRule"
                   - "events:DescribeRule"
-                  - "events:RemoveTargets"
                 Resource:
                   - !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForECSTaskRule"
         - PolicyName: GrantAccessToRulePolicy
@@ -1270,9 +1269,9 @@ Resources:
       RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
 
 
-  StartHarvestAndCreateCSVRule:
+  StartHarvestAndCreateStandardJsonRule:
     Type: AWS::Events::Rule
-    Condition: CreateHarvestAndCSVRule
+    Condition: CreateHarvestAndStdJsonCondition
     Properties:
       Description: "Starts the Step Functions to harvest metadata and create standard json."
       ScheduleExpression: "cron(0 6 * * ? *)"
@@ -1285,7 +1284,7 @@ Resources:
 
   StartManifestPipelineRule:
     Type: AWS::Events::Rule
-    Condition: CreateHarvestAndCSVRule
+    Condition: CreateHarvestAndStdJsonCondition
     Properties:
       Description: "Starts the Step Functions to process images and create manifests."
       ScheduleExpression: "cron(0 8 * * ? *)"


### PR DESCRIPTION
* Changed manifest-pipeline-pipeline.yml
  * Added events:RemoveTargets permission to CloudFormationRolePolicy
  * Also added resource StartHarvestAndCreateStandardJsonRule to allow me to rename the old rule from StartHarvestAndCreateCSVRule to StartHarvestAndCreateStandardJsonRule.

* Changed manifest-pipeline.yml
  * renamed StartHarvestAndCreateCSVRule to StartHarvestAndCreateStandardJsonRule to describe what is now does.
  * removed "events:RemoveTargets" from FargateTaskPolicy where I had put it before incorrectly.