### PR TITLE
Change namespaced context handling

### DIFF
--- a/deploy/cdk/bin/base.ts
+++ b/deploy/cdk/bin/base.ts
@@ -7,7 +7,23 @@ import IIIF = require('../lib/iiif-serverless');
 import userContent = require('../lib/user-content');
 import imageProcessing = require('../lib/image-processing');
 
+const allContext = JSON.parse(process.env.CDK_CONTEXT_JSON ?? "{}");
+
 const app = new App();
+
+// Globs all kvp from context of the form "namespace:key": "value"
+// and flattens it to an object of the form "key": "value"
+const getContextByNamespace = (ns: string) : any => {
+  const result: any = {};
+  const prefix = `${ns}:`;
+  for (const [key, value] of Object.entries(allContext)) {
+    if(key.startsWith(prefix)){
+      const flattenedKey =  key.substr(prefix.length);
+      result[flattenedKey] = value;
+    }
+  };
+  return result;
+}
 
 const getRequiredContext = (key: string) => {
   const value = app.node.tryGetContext(key);
@@ -50,56 +66,37 @@ new IIIF.DeploymentPipelineStack(app, `${namespace}-image-service-deployment`, {
   ...imageServiceContext
 });
 
-const userContentContext = {
+const userContentContext = getContextByNamespace('userContent');
+const userContentProps = {
   env,
-  allowedOrigins: app.node.tryGetContext('userContent:allowedOrigins'),
-  lambdaCodePath: app.node.tryGetContext('userContent:lambdaCodePath'),
-  tokenAudiencePath: app.node.tryGetContext('userContent:tokenAudiencePath'),
-  tokenIssuerPath: app.node.tryGetContext('userContent:tokenIssuerPath'),
-  appRepoOwner: app.node.tryGetContext('userContent:appRepoOwner'),
-  appRepoName: app.node.tryGetContext('userContent:appRepoName'),
-  appSourceBranch: app.node.tryGetContext('userContent:appSourceBranch'),
-  infraRepoOwner: app.node.tryGetContext('userContent:infraRepoOwner'),
-  infraRepoName: app.node.tryGetContext('userContent:infraRepoName'),
-  infraSourceBranch: app.node.tryGetContext('userContent:infraSourceBranch'),
-  notificationReceivers: app.node.tryGetContext('userContent:deployNotificationReceivers'),
-  hostnamePrefix: app.node.tryGetContext('userContent:hostnamePrefix'),
   foundationStack,
   createDns,
   namespace,
-};
-new userContent.UserContentStack(app, `${namespace}-user-content`, userContentContext);
+  ...userContentContext,
+}
+new userContent.UserContentStack(app, `${namespace}-user-content`, userContentProps);
 new userContent.DeploymentPipelineStack(app, `${namespace}-user-content-deployment`, {
   contextEnvName: envName,
   oauthTokenPath,
   owner,
   contact,
   slackNotifyStackName,
-  ...userContentContext,
+  ...userContentProps,
 });
 
-const imageProcessingContext = {
+const imageProcessingContext = getContextByNamespace('imageProcessing');
+const imageProcessingProps = {
   env,
-  rbscBucketName: app.node.tryGetContext('imageProcessing:rbscBucketName'),
-  processBucketName: app.node.tryGetContext('imageProcessing:processBucketName'),
-  imageBucketName: app.node.tryGetContext('imageProcessing:imageBucketName'),
-  lambdaCodePath: app.node.tryGetContext('imageProcessing:lambdaCodePath'),
-  dockerfilePath: app.node.tryGetContext('imageProcessing:dockerfilePath'),
-  appRepoOwner: app.node.tryGetContext('imageProcessing:appRepoOwner'),
-  appRepoName: app.node.tryGetContext('imageProcessing:appRepoName'),
-  appSourceBranch: app.node.tryGetContext('imageProcessing:appSourceBranch'),
-  infraRepoOwner: app.node.tryGetContext('imageProcessing:infraRepoOwner'),
-  infraRepoName: app.node.tryGetContext('imageProcessing:infraRepoName'),
-  infraSourceBranch: app.node.tryGetContext('imageProcessing:infraSourceBranch'),
   foundationStack,
+  ...imageProcessingContext,
 };
-new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, imageProcessingContext);
+new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, imageProcessingProps);
 new imageProcessing.DeploymentPipelineStack(app, `${namespace}-image-processing-deployment`, {
   contextEnvName: envName,
   oauthTokenPath,
   owner,
   contact,
   namespace,
-  ...imageProcessingContext,
+  ...imageProcessingProps,
 });
 app.node.applyAspect(new StackTags());


### PR DESCRIPTION
We have several key value pairs in our context that are directly mapped
to stack props. These kvp are namespaced as "namespace:key". I found a
way to get all context from an env variable so that we can just glob all
of these and pass them into the stacks. This should make it cleaner and
easier to add new context/props to stacks.