### PR TITLE
WIP: Separate services from pipelines

### DIFF
--- a/deploy/cdk/bin/base.ts
+++ b/deploy/cdk/bin/base.ts
@@ -2,173 +2,29 @@
 import { App } from '@aws-cdk/core'
 import { StackTags } from '@ndlib/ndlib-cdk'
 import 'source-map-support/register'
-import { FoundationStack } from '../lib/foundation'
-import IIIF = require('../lib/iiif-serverless')
-import userContent = require('../lib/user-content')
-import imageProcessing = require('../lib/image-processing')
-import elasticsearch = require('../lib/elasticsearch')
-import staticHost = require('../lib/static-host')
-import manifestPipeline = require('../lib/manifest-pipeline')
-
-const allContext = JSON.parse(process.env.CDK_CONTEXT_JSON ?? "{}")
+import { getRequiredContext } from '../lib/context-helpers'
+import * as services from './services'
+import * as pipelines from './codepipelines'
 
 const app = new App()
 
-// Globs all kvp from context of the form "namespace:key": "value"
-// and flattens it to an object of the form "key": "value"
-const getContextByNamespace = (ns: string): any => {
-  const result: any = {}
-  const prefix = `${ns}:`
-  for (const [key, value] of Object.entries(allContext)) {
-    if(key.startsWith(prefix)){
-      const flattenedKey =  key.substr(prefix.length)
-      result[flattenedKey] = value
-    }
-  }
-  return result
-}
-
-const getRequiredContext = (key: string) => {
-  const value = app.node.tryGetContext(key)
-  if(value === undefined || value === null) {
-    throw new Error(`Context key '${key}' is required.`)
-  }
-  return value
-}
-
-// Get context keys that are required by all stacks
-const owner = getRequiredContext('owner')
-const contact = getRequiredContext('contact')
-const namespace = getRequiredContext('namespace')
-const envName = getRequiredContext('env')
-const contextEnv = getRequiredContext('environments')[envName]
+const stackType = getRequiredContext(app.node, 'stackType')
+const namespace = getRequiredContext(app.node, 'namespace')
+const envName = getRequiredContext(app.node, 'env')
+const contextEnv = getRequiredContext(app.node, 'environments')[envName]
 if(contextEnv === undefined || contextEnv === null) {
   throw new Error(`Context key 'environments.${envName}' is required.`)
 }
-
-// The environment objects defined in our context are a mixture of properties.
-// Need to decompose these into a cdk env object and other required stack props
 const env = { account: contextEnv.account, region: contextEnv.region, name: envName }
-const { useVpcId, domainName, createDns, useExistingDnsZone, slackNotifyStackName, rBSCS3ImageBucketName, createEventRules } = contextEnv
 
-const oauthTokenPath = app.node.tryGetContext('oauthTokenPath')
-const projectName = getRequiredContext('projectName')
-const description = getRequiredContext('description')
-
-const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
-  env,
-  domainName,
-  useExistingDnsZone,
-  useVpcId,
-})
-
-const staticHostContext = getContextByNamespace('staticHost')
-const staticHostProps = {
-  contextEnvName: envName,
-  env,
-  foundationStack,
-  createDns,
-  namespace,
-  ...staticHostContext,
+switch(stackType) {
+  case 'service':
+    services.instantiateStacks(app, namespace, env, contextEnv, envName)
+    break
+  case 'pipeline':
+    pipelines.instantiateStacks(app, namespace, env, contextEnv, envName)
+    break
+  default:
+    throw new Error(`Context key stackType must be on of 'service' or 'pipelines'. Got ${stackType}.`)
 }
-const siteInstances = [
-  'website', // Main marble site
-  'redbox',
-]
-siteInstances.map(instanceName => {
-  new staticHost.StaticHostStack(app, `${namespace}-${instanceName}`, staticHostProps)
-  new staticHost.DeploymentPipelineStack(app, `${namespace}-${instanceName}-deployment`, {
-    oauthTokenPath,
-    owner,
-    contact,
-    projectName,
-    description,
-    slackNotifyStackName,
-    instanceName,
-    ...staticHostProps,
-  })
-})
-
-const imageServiceContext = getContextByNamespace('iiifImageService')
-new IIIF.IiifServerlessStack(app, `${namespace}-image-service`, {
-  env,
-  foundationStack,
-  createDns,
-  ...imageServiceContext,
-})
-new IIIF.DeploymentPipelineStack(app, `${namespace}-image-service-deployment`, {
-  contextEnvName: envName,
-  owner,
-  contact,
-  createDns,
-  domainStackName: `${namespace}-domain`,
-  oauthTokenPath,
-  namespace,
-  domainName,
-  slackNotifyStackName,
-  ...imageServiceContext,
-})
-
-const userContentContext = getContextByNamespace('userContent')
-const userContentProps = {
-  env,
-  foundationStack,
-  createDns,
-  namespace,
-  ...userContentContext,
-}
-new userContent.UserContentStack(app, `${namespace}-user-content`, userContentProps)
-new userContent.DeploymentPipelineStack(app, `${namespace}-user-content-deployment`, {
-  contextEnvName: envName,
-  oauthTokenPath,
-  owner,
-  contact,
-  slackNotifyStackName,
-  ...userContentProps,
-})
-
-const imageProcessingContext = getContextByNamespace('imageProcessing')
-const imageProcessingProps = {
-  env,
-  foundationStack,
-  ...imageProcessingContext,
-}
-new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, imageProcessingProps)
-new imageProcessing.DeploymentPipelineStack(app, `${namespace}-image-processing-deployment`, {
-  contextEnvName: envName,
-  oauthTokenPath,
-  owner,
-  contact,
-  namespace,
-  ...imageProcessingProps,
-})
-const elasticsearchContext = getContextByNamespace('elasticsearch')
-const elasticsearchProps = {
-  env,
-  contextEnvName: envName,
-  namespace,
-  foundationStack,
-  ...elasticsearchContext,
-}
-new elasticsearch.ElasticStack(app, `${namespace}-elastic`, elasticsearchProps)
-new elasticsearch.DeploymentPipelineStack(app, `${namespace}-elastic-deployment`, {
-  oauthTokenPath,
-  owner,
-  contact,
-  ...elasticsearchProps,
-})
-
-const manifestPipelineContext = getContextByNamespace('manifestPipeline')
-const manifestPipelineProps = {
-  env,
-  domainName,
-  foundationStack,
-  createDns,
-  sentryDsn: app.node.tryGetContext('sentryDsn'),
-  rBSCS3ImageBucketName,
-  createEventRules,
-  appConfigPath: `/all/${namespace}-manifest`,
-  ...manifestPipelineContext,
-}
-new manifestPipeline.ManifestPipelineStack(app, `${namespace}-manifest`, manifestPipelineProps)
 app.node.applyAspect(new StackTags())

--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { App } from '@aws-cdk/core'
+import { StackTags } from '@ndlib/ndlib-cdk'
+import 'source-map-support/register'
+import { FoundationStack } from '../lib/foundation'
+import IIIF = require('../lib/iiif-serverless')
+import userContent = require('../lib/user-content')
+import imageProcessing = require('../lib/image-processing')
+import staticHost = require('../lib/static-host')
+import { getRequiredContext, getContextByNamespace } from '../lib/context-helpers'
+import { Environment } from '@aws-cdk/cx-api'
+
+export const instantiateStacks = (app: App, namespace: string, env: Environment, contextEnv: any, envName: string): void => {
+
+  // Get context keys that are required by all stacks
+  const owner = getRequiredContext(app.node, 'owner')
+  const contact = getRequiredContext(app.node, 'contact')
+
+  // // The environment objects defined in our context are a mixture of properties.
+  // // Need to decompose these into a cdk env object and other required stack props
+  const { useVpcId, domainName, createDns, useExistingDnsZone, slackNotifyStackName } = contextEnv
+
+  const oauthTokenPath = app.node.tryGetContext('oauthTokenPath')
+  const projectName = getRequiredContext(app.node, 'projectName')
+  const description = getRequiredContext(app.node, 'description')
+
+  // Pipelines will expect there to be a test and prod foundation stack to build the services on
+  const testFoundationStack = new FoundationStack(app, `${namespace}-test-foundation`, {
+    env,
+    domainName,
+    useExistingDnsZone,
+    useVpcId,
+  })
+  const prodFoundationStack = new FoundationStack(app, `${namespace}-prod-foundation`, {
+    env,
+    domainName,
+    useExistingDnsZone,
+    useVpcId,
+  })
+
+  const staticHostContext = getContextByNamespace('staticHost')
+  const siteInstances = [
+    'website', // Main marble site
+    'redbox',
+  ]
+  siteInstances.map(instanceName => {
+    new staticHost.DeploymentPipelineStack(app, `${namespace}-${instanceName}-deployment`, {
+      oauthTokenPath,
+      owner,
+      contact,
+      projectName,
+      description,
+      slackNotifyStackName,
+      instanceName,
+      contextEnvName: envName,
+      env,
+      createDns,
+      namespace,
+      foundationStack: testFoundationStack,
+      ...staticHostContext,
+    })
+  })
+
+  const imageServiceContext = getContextByNamespace('iiifImageService')
+  new IIIF.DeploymentPipelineStack(app, `${namespace}-image-service-deployment`, {
+    contextEnvName: envName,
+    owner,
+    contact,
+    createDns,
+    oauthTokenPath,
+    namespace,
+    testFoundationStack,
+    prodFoundationStack,
+    slackNotifyStackName,
+    ...imageServiceContext,
+  })
+
+  const userContentContext = getContextByNamespace('userContent')
+  new userContent.DeploymentPipelineStack(app, `${namespace}-user-content-deployment`, {
+    contextEnvName: envName,
+    oauthTokenPath,
+    owner,
+    contact,
+    slackNotifyStackName,
+    env,
+    createDns,
+    namespace,
+    foundationStack: testFoundationStack,
+    ...userContentContext,
+  })
+
+  const imageProcessingContext = getContextByNamespace('imageProcessing')
+  new imageProcessing.DeploymentPipelineStack(app, `${namespace}-image-processing-deployment`, {
+    contextEnvName: envName,
+    oauthTokenPath,
+    owner,
+    contact,
+    namespace,
+    env,
+    ...imageProcessingContext,
+  })
+}

--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { App, Environment } from '@aws-cdk/core'
+import 'source-map-support/register'
+import { FoundationStack } from '../lib/foundation'
+import IIIF = require('../lib/iiif-serverless')
+import userContent = require('../lib/user-content')
+import imageProcessing = require('../lib/image-processing')
+import elasticsearch = require('../lib/elasticsearch')
+import staticHost = require('../lib/static-host')
+import manifestPipeline = require('../lib/manifest-pipeline')
+import { getContextByNamespace } from '../lib/context-helpers'
+
+// TODO: use better typing for the env params
+export const instantiateStacks = (app: App, namespace: string, env: Environment, contextEnv: any, envName: string): void => {
+  
+  // The environment objects defined in our context are a mixture of properties.
+  // Need to decompose these into a cdk env object and other required stack props
+  const { useVpcId, domainName, createDns, useExistingDnsZone, rBSCS3ImageBucketName, createEventRules } = contextEnv
+
+  const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
+    env,
+    domainName,
+    useExistingDnsZone,
+    useVpcId,
+  })
+
+  const staticHostContext = getContextByNamespace('staticHost')
+  const siteInstances = [
+    'website', // Main marble site
+    'redbox',
+  ]
+  siteInstances.map(instanceName => {
+    new staticHost.StaticHostStack(app, `${namespace}-${instanceName}`, {
+      contextEnvName: envName,
+      env,
+      foundationStack,
+      createDns,
+      namespace,
+      ...staticHostContext,
+    })
+  })
+
+  const imageServiceContext = getContextByNamespace('iiifImageService')
+  new IIIF.IiifServerlessStack(app, `${namespace}-image-service`, {
+    env,
+    foundationStack,
+    createDns,
+    ...imageServiceContext,
+  })
+
+  const userContentContext = getContextByNamespace('userContent')
+  new userContent.UserContentStack(app, `${namespace}-user-content`, {
+    env,
+    foundationStack,
+    createDns,
+    namespace,
+    ...userContentContext,
+  })
+
+  const imageProcessingContext = getContextByNamespace('imageProcessing')
+  new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, {
+    env,
+    foundationStack,
+    ...imageProcessingContext,
+  })
+
+  const elasticsearchContext = getContextByNamespace('elasticsearch')
+  new elasticsearch.ElasticStack(app, `${namespace}-elastic`, {
+    env,
+    contextEnvName: envName,
+    namespace,
+    foundationStack,
+    ...elasticsearchContext,
+  })
+
+
+  const manifestPipelineContext = getContextByNamespace('manifestPipeline')
+  new manifestPipeline.ManifestPipelineStack(app, `${namespace}-manifest`, {
+    env,
+    domainName,
+    foundationStack,
+    createDns,
+    sentryDsn: app.node.tryGetContext('sentryDsn'),
+    rBSCS3ImageBucketName,
+    createEventRules,
+    appConfigPath: `/all/${namespace}-manifest`,
+    ...manifestPipelineContext,
+  })
+}

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -29,6 +29,7 @@
   "description": "Infrastructure for Marble project",
   "oauthTokenPath": "/all/github/ndlib-git",
   "namespace": "marble",
+  "stackType": "service",
   "iiifImageService:serverlessIiifSrcPath": "../../../serverless-iiif",
   "iiifImageService:hostnamePrefix": "image-iiif",
   "iiifImageService:appRepoOwner": "ndlib",

--- a/deploy/cdk/lib/context-helpers.ts
+++ b/deploy/cdk/lib/context-helpers.ts
@@ -1,0 +1,25 @@
+import { ConstructNode } from "@aws-cdk/core"
+
+const allContext = JSON.parse(process.env.CDK_CONTEXT_JSON ?? "{}")
+
+// Globs all kvp from context of the form "namespace:key": "value"
+// and flattens it to an object of the form "key": "value"
+export const getContextByNamespace = (ns: string): any => {
+  const result: any = {}
+  const prefix = `${ns}:`
+  for (const [key, value] of Object.entries(allContext)) {
+    if(key.startsWith(prefix)){
+      const flattenedKey =  key.substr(prefix.length)
+      result[flattenedKey] = value
+    }
+  }
+  return result
+}
+
+export const getRequiredContext = (node: ConstructNode, key: string) => {
+  const value = node.tryGetContext(key)
+  if(value === undefined || value === null) {
+    throw new Error(`Context key '${key}' is required.`)
+  }
+  return value
+}


### PR DESCRIPTION
Developing and deploying cd pipelines is a different type of activity
from developing and deploying the service stacks. In addition to this,
we are now creating separate foundation stacks for test and prod, but not
specifically instantiating these stacks in the cdk app is an anti-pattern.
Putting all of these things in base.ts was becoming harder to parse and
understand. This is an attempt at separating these types of activities,
without completely separating pipelines into their own app (which is an
option but would require bigger changes). The idea is that you will now
have to pass an additional context variable called `stackType`. The
available stacks to deploy will depend on what is given for this context
variable, either `service` or `pipeline`. `service` will be the default
to retain backward compatibility with both devs and pipelines.

Here's the output of `cdk list` as an example:
```
$ cdk list -c env=dev
marble-elastic
marble-foundation
marble-image-processing
marble-image-service
marble-manifest
marble-redbox
marble-user-content
marble-website

$ cdk list -c env=dev -c stackType=pipeline
marble-image-processing-deployment
marble-image-service-deployment
marble-prod-foundation
marble-test-foundation
marble-user-content-deployment
marble-redbox-deployment
marble-website-deployment
```