### PR TITLE
Separate services from pipelines

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { App } from '@aws-cdk/core'
+import 'source-map-support/register'
+import IIIF = require('../lib/iiif-serverless')
+import userContent = require('../lib/user-content')
+import imageProcessing = require('../lib/image-processing')
+import staticHost = require('../lib/static-host')
+import elasticsearch = require('../lib/elasticsearch')
+import manifestPipeline = require('../lib/manifest-pipeline')
+import { getRequiredContext, getContextByNamespace } from '../lib/context-helpers'
+import { ContextEnv } from '../lib/context-env'
+
+export const instantiateStacks = (app: App, namespace: string, contextEnv: ContextEnv, testStacks: any, prodStacks: any): void => {
+
+  // Get context keys that are required by all stacks
+  const owner = getRequiredContext(app.node, 'owner')
+  const contact = getRequiredContext(app.node, 'contact')
+  const oauthTokenPath = app.node.tryGetContext('oauthTokenPath')
+  const projectName = getRequiredContext(app.node, 'projectName')
+  const description = getRequiredContext(app.node, 'description')
+
+  // // The environment objects defined in our context are a mixture of properties.
+  // // Need to decompose these into a cdk env object and other required stack props
+  const { env, createDns, slackNotifyStackName } = contextEnv
+
+  const staticHostContext = getContextByNamespace('staticHost')
+  const siteInstances = [
+    'website', // Main marble site
+    'redbox',
+  ]
+  siteInstances.map(instanceName => {
+    new staticHost.DeploymentPipelineStack(app, `${namespace}-${instanceName}-deployment`, {
+      oauthTokenPath,
+      owner,
+      contact,
+      projectName,
+      description,
+      slackNotifyStackName,
+      instanceName,
+      contextEnvName: contextEnv.name,
+      env,
+      createDns,
+      namespace,
+      testFoundationStack: testStacks.foundationStack,
+      prodFoundationStack: prodStacks.foundationStack,
+      ...staticHostContext,
+    })
+  })
+
+  const imageServiceContext = getContextByNamespace('iiifImageService')
+  const imageServicePipeline = new IIIF.DeploymentPipelineStack(app, `${namespace}-image-service-deployment`, {
+    env,
+    contextEnvName: contextEnv.name,
+    owner,
+    contact,
+    createDns,
+    oauthTokenPath,
+    namespace,
+    testFoundationStack: testStacks.foundationStack,
+    prodFoundationStack: prodStacks.foundationStack,
+    slackNotifyStackName,
+    ...imageServiceContext,
+  })
+
+  const userContentContext = getContextByNamespace('userContent')
+  new userContent.DeploymentPipelineStack(app, `${namespace}-user-content-deployment`, {
+    contextEnvName: contextEnv.name,
+    oauthTokenPath,
+    owner,
+    contact,
+    slackNotifyStackName,
+    env,
+    createDns,
+    namespace,
+    testFoundationStack: testStacks.foundationStack,
+    prodFoundationStack: prodStacks.foundationStack,
+    ...userContentContext,
+  })
+
+  const imageProcessingContext = getContextByNamespace('imageProcessing')
+  new imageProcessing.DeploymentPipelineStack(app, `${namespace}-image-processing-deployment`, {
+    contextEnvName: contextEnv.name,
+    oauthTokenPath,
+    owner,
+    contact,
+    namespace,
+    env,
+    ...imageProcessingContext,
+  })
+
+  const elasticsearchContext = getContextByNamespace('elasticsearch')
+  new elasticsearch.DeploymentPipelineStack(app, `${namespace}-elastic-deployment`, {
+    env,
+    contextEnvName: contextEnv.name,
+    namespace,
+    oauthTokenPath,
+    owner,
+    contact,
+    ...elasticsearchContext,
+  })
+
+  const manifestPipelineContext = getContextByNamespace('manifestPipeline')
+  new manifestPipeline.DeploymentPipelineStack(app, `${namespace}-manifest-deployment`, {
+    contextEnvName: contextEnv.name,
+    oauthTokenPath,
+    owner,
+    contact,
+    namespace,
+    slackNotifyStackName,
+    ...manifestPipelineContext,
+  })
+}

--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import { App } from '@aws-cdk/core'
+import 'source-map-support/register'
+import { FoundationStack } from '../lib/foundation'
+import IIIF = require('../lib/iiif-serverless')
+import userContent = require('../lib/user-content')
+import imageProcessing = require('../lib/image-processing')
+import elasticsearch = require('../lib/elasticsearch')
+import staticHost = require('../lib/static-host')
+import manifestPipeline = require('../lib/manifest-pipeline')
+import { getContextByNamespace } from '../lib/context-helpers'
+import { ContextEnv } from '../lib/context-env'
+
+
+export const instantiateStacks = (app: App, namespace: string, contextEnv: ContextEnv): any => {
+  // The environment objects defined in our context are a mixture of properties.
+  // Need to decompose these into a cdk env object and other required stack props
+  const { env, useVpcId, domainName, createDns, useExistingDnsZone, rBSCS3ImageBucketName } = contextEnv
+
+  const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
+    env,
+    domainName,
+    useExistingDnsZone,
+    useVpcId,
+  })
+
+  // TODO: Change this to use unique context namespaces
+  const staticHostContext = getContextByNamespace('staticHost')
+  const siteInstances = [
+    'website', // Main marble site
+    'redbox',
+  ]
+  const siteStacks = siteInstances.map(instanceName => {
+    new staticHost.StaticHostStack(app, `${namespace}-${instanceName}`, {
+      contextEnvName: contextEnv.name,
+      env,
+      foundationStack,
+      createDns,
+      namespace,
+      ...staticHostContext,
+    })
+  })
+
+  const imageServiceContext = getContextByNamespace('iiifImageService')
+  const iiifServerlessStack = new IIIF.IiifServerlessStack(app, `${namespace}-image-service`, {
+    env,
+    foundationStack,
+    createDns,
+    ...imageServiceContext,
+  })
+
+  const userContentContext = getContextByNamespace('userContent')
+  const userContentStack = new userContent.UserContentStack(app, `${namespace}-user-content`, {
+    env,
+    foundationStack,
+    createDns,
+    namespace,
+    ...userContentContext,
+  })
+
+  const imageProcessingContext = getContextByNamespace('imageProcessing')
+  const imageProcessingStack = new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, {
+    env,
+    foundationStack,
+    ...imageProcessingContext,
+  })
+
+  const elasticsearchContext = getContextByNamespace('elasticsearch')
+  const elasticSearchStack = new elasticsearch.ElasticStack(app, `${namespace}-elastic`, {
+    env,
+    contextEnvName: contextEnv.name,
+    namespace,
+    foundationStack,
+    ...elasticsearchContext,
+  })
+
+
+  const manifestPipelineContext = getContextByNamespace('manifestPipeline')
+  const manifestPipelineStack = new manifestPipeline.ManifestPipelineStack(app, `${namespace}-manifest`, {
+    env,
+    domainName,
+    foundationStack,
+    createDns,
+    sentryDsn: app.node.tryGetContext('sentryDsn'),
+    rBSCS3ImageBucketName,
+    createEventRules: app.node.tryGetContext('manifestPipeline:createEventRules') === "true" ? true : false,
+    appConfigPath: app.node.tryGetContext('manifestPipeline:appConfigPath') ? app.node.tryGetContext('manifestPipeline:appConfigPath') : `/all/stacks/${namespace}-manifest`,
+    ...manifestPipelineContext,
+  })
+
+  return {
+    foundationStack,
+    siteStacks,
+    iiifServerlessStack,
+    userContentStack,
+    imageProcessingStack,
+    elasticSearchStack,
+    manifestPipelineStack,
+  }
+}

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -27,6 +27,7 @@
   "description": "Infrastructure for Marble project",
   "oauthTokenPath": "/all/github/ndlib-git",
   "namespace": "marble",
+  "stackType": "service",
   "iiifImageService:serverlessIiifSrcPath": "../../../serverless-iiif",
   "iiifImageService:hostnamePrefix": "image-iiif",
   "iiifImageService:appRepoOwner": "ndlib",

--- a/deploy/cdk/lib/context-env.ts
+++ b/deploy/cdk/lib/context-env.ts
@@ -1,0 +1,25 @@
+import { Environment } from "@aws-cdk/cx-api";
+import { ConstructNode } from "@aws-cdk/core";
+import { getRequiredContext } from "./context-helpers";
+
+export class ContextEnv {
+  readonly name: string
+  readonly env: Environment
+  readonly useVpcId: string
+  readonly createDns: boolean
+  readonly domainName: string
+  readonly useExistingDnsZone: boolean
+  readonly slackNotifyStackName: string
+  readonly rBSCS3ImageBucketName: string
+  readonly createEventRules: boolean
+
+  static fromContext = (node: ConstructNode, name: string): ContextEnv => {
+    const contextEnv = getRequiredContext(node, 'environments')[name]
+    if(contextEnv === undefined || contextEnv === null) {
+      throw new Error(`Context key 'environments.${name}' is required.`)
+    }
+    contextEnv.name = name
+    contextEnv.env = { account: contextEnv.account, region: contextEnv.region, name: contextEnv.name }
+    return contextEnv
+  }
+}

--- a/deploy/cdk/lib/context-helpers.ts
+++ b/deploy/cdk/lib/context-helpers.ts
@@ -1,0 +1,25 @@
+import { ConstructNode } from "@aws-cdk/core"
+
+const allContext = JSON.parse(process.env.CDK_CONTEXT_JSON ?? "{}")
+
+// Globs all kvp from context of the form "namespace:key": "value"
+// and flattens it to an object of the form "key": "value"
+export const getContextByNamespace = (ns: string): any => {
+  const result: any = {}
+  const prefix = `${ns}:`
+  for (const [key, value] of Object.entries(allContext)) {
+    if(key.startsWith(prefix)){
+      const flattenedKey =  key.substr(prefix.length)
+      result[flattenedKey] = value
+    }
+  }
+  return result
+}
+
+export const getRequiredContext = (node: ConstructNode, key: string) => {
+  const value = node.tryGetContext(key)
+  if(value === undefined || value === null) {
+    throw new Error(`Context key '${key}' is required.`)
+  }
+  return value
+}


### PR DESCRIPTION
Developing and deploying cd pipelines is a different type of activity
from developing and deploying the service stacks. In addition to this,
we are now creating separate foundation stacks for test and prod, but not
specifically instantiating these stacks in the cdk app, which is an
anti-pattern. Putting all of these things in base.ts was becoming harder
to parse and understand. This is an attempt at separating these types of
activities. The idea is that you will now have to pass an additional
context variable called `stackType`. The available stacks to deploy will
depend on what is given for this context variable, either `service` or
`pipeline`. `service` will be the default to retain backward compatibility
with both devs and pipelines.

Here's the output of `cdk list` as an example:
```
$ cdk list -c env=dev
marble-elastic
marble-foundation
marble-image-processing
marble-image-service
marble-manifest
marble-redbox
marble-user-content
marble-website

$ cdk list -c env=dev -c stackType=pipeline
marble-image-processing-deployment
marble-prod-elastic
marble-prod-foundation
marble-test-elastic
marble-test-foundation
marble-user-content-deployment
marble-image-service-deployment
marble-prod-image-processing
marble-prod-image-service
marble-prod-manifest
marble-prod-redbox
marble-prod-user-content
marble-prod-website
marble-redbox-deployment
marble-test-image-processing
marble-test-image-service
marble-test-manifest
marble-test-redbox
marble-test-user-content
marble-test-website
marble-website-deployment
```

With this change, if your pipeline needs to reference any resources from
the foundation stack, you'll need to pass both the test and prod instances.
I've converted the existing ones to do this, and with this was also able
to add a stage in the IIIF pipeline that will copy the test images into
the target test/prod buckets before performing tests, making the entire
pipeline much easier to prop up from scratch.