### PR TITLE
Fix context override for static host pipelines

### DIFF
--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -77,7 +77,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           projectName: props.projectName,
           owner: props.owner,
           contact: props.contact,
-          'staticHost:hostnamePrefix': hostnamePrefix,
+          [`${props.instanceName}:hostnamePrefix`]: hostnamePrefix,
         },
       })
       cdkDeploy.project.addToRolePolicy(new PolicyStatement({


### PR DESCRIPTION
This fixes the pipeline to override the correct context for the instance that it's deploying.