### PR TITLE
Fix issues in image processing CD pipeline

### DIFF
--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -56,13 +56,6 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     ...userContentContext,
   })
 
-  const imageProcessingContext = getContextByNamespace('imageProcessing')
-  const imageProcessingStack = new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, {
-    foundationStack,
-    ...commonProps,
-    ...imageProcessingContext,
-  })
-
   const elasticsearchContext = getContextByNamespace('elasticsearch')
   const elasticSearchStack = new elasticsearch.ElasticStack(app, `${namespace}-elastic`, {
     foundationStack,
@@ -80,6 +73,15 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     rBSCS3ImageBucketName: contextEnv.rBSCS3ImageBucketName,
     ...commonProps,
     ...manifestPipelineContext,
+  })
+
+  const imageProcessingContext = getContextByNamespace('imageProcessing')
+  const imageProcessingStack = new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, {
+    foundationStack,
+    rbscBucketName: contextEnv.rBSCS3ImageBucketName,
+    manifestPipelineStack,
+    ...commonProps,
+    ...imageProcessingContext,
   })
 
   return {

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -43,12 +43,6 @@
   "iiifImageService:qaRepoName": "iiif-qa",
   "iiifImageService:qaSourceBranch": "master",
 
-  "imageProcessing:prodRbscBucketName": "libnd-smb-rbsc",
-  "imageProcessing:prodProcessBucketName": "marble-manifest-prod-processbucket-kskqchthxshg",
-  "imageProcessing:prodImageBucketName": "marble-data-broker-publicbucket-1kvqtwnvkhra2",
-  "imageProcessing:rbscBucketName": "marble-rbsc",
-  "imageProcessing:processBucketName": "marble-image",
-  "imageProcessing:imageBucketName": "marble-image",
   "imageProcessing:lambdaCodePath": "../../../marble-images/s3_event",
   "imageProcessing:dockerfilePath": "../../../marble-images/",
   "imageProcessing:appRepoOwner": "ndlib",


### PR DESCRIPTION
- Changed image processing pipeline to get manifest pipeline bucket names
from other stacks instead of requiring them via context
- Changed image processing to use the env config to get the rbsc bucket
since that changes per env
- Fixed an issue with the target stack names. We had changed them from
`marble-image` to `marble-image-processing` but had missed updating the
pipeline to use these names when deploying.
- Fixed an issue with the code terminating too soon during synth,
preventing cdk from seeing dependencies correctly. We need to find an
alternative solution to the `if !fs.existsSync(props.lambdaCodePath); return`
checks that still allow the code to continue, but still throws an error
when that stack is deployed. In this specific case, cdk was not seeing
the dependency between image processing and manifest pipeline because
the manifest pipeline was exiting too soon due to the missing files. For
now, I just moved these fs checks down a bit and forced the export/import
to happen in the manifest pipeline. This is a pretty fragile solution,
and it's not very intuitive what's happening when this occurs, so I'm
going to look for a more general solution to this, but this fixes the
immediate issue for now. See https://github.com/aws/aws-cdk/issues/6743
for the original issue we were trying to prevent with these checks.