### PR TITLE
Fix search url

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -41,6 +41,8 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     const instanceContext = getContextByNamespace(instanceName)
     new staticHost.DeploymentPipelineStack(app, `${namespace}-${instanceName}-deployment`, {
       instanceName,
+      testElasticStack: testStacks.elasticSearchStack,
+      prodElasticStack: prodStacks.elasticSearchStack,
       ...commonProps,
       ...staticHostContext,
       ...instanceContext,

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -57,7 +57,7 @@
   "website:buildOutputDir": "public",
   "website:lambdaCodePath": "../../src/unifiedEdgeLambda",
   "website:qaSpecPath": "tests/postman/collection.json",
-  "website:elasticSearchDomain": "marble",
+  "website:searchIndex": "marble",
 
   "redbox:hostnamePrefix": "redbox",
   "redbox:appRepoOwner": "ndlib",
@@ -67,9 +67,7 @@
   "redbox:buildOutputDir": "public",
   "redbox:lambdaCodePath": "../../src/unifiedEdgeLambda",
   "redbox:qaSpecPath": "tests/postman/collection.json",
-  "redbox:elasticSearchDomain": "marble",
-
-  "elasticsearch:esDomainName": "sites",
+  "redbox:searchIndex": "redbox",
 
   "userContent:allowedOrigins": "*",
   "userContent:lambdaCodePath": "../../../marble-user-content/src",

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -67,7 +67,6 @@
   "redbox:buildOutputDir": "public",
   "redbox:lambdaCodePath": "../../src/unifiedEdgeLambda",
   "redbox:qaSpecPath": "tests/postman/collection.json",
-  "redbox:searchIndex": "redbox",
 
   "userContent:allowedOrigins": "*",
   "userContent:lambdaCodePath": "../../../marble-user-content/src",

--- a/deploy/cdk/lib/cdk-pipeline-deploy.ts
+++ b/deploy/cdk/lib/cdk-pipeline-deploy.ts
@@ -122,6 +122,7 @@ export class CDKPipelineDeploy extends Construct {
         },
         version: '0.2',
       }),
+      ...props,
     })
 
     // CDK will try to read logs when generating output for failed events

--- a/deploy/cdk/lib/elasticsearch/deployment-pipeline.ts
+++ b/deploy/cdk/lib/elasticsearch/deployment-pipeline.ts
@@ -31,7 +31,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const prodStackName = `${props.namespace}-prod-elastic`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, domainName: string) => {
+    const createDeploy = (targetStack: string, namespace: string) => {
       const cdkDeploy = new CDKPipelineDeploy(this, `${namespace}-deploy`, {
         targetStack,
         dependsOnStacks: [],
@@ -45,10 +45,9 @@ export class DeploymentPipelineStack extends cdk.Stack {
           projectName: "marble",
           owner: props.owner,
           contact: props.contact,
-          "elasticsearch:esDomainName": domainName,
         },
       })
-      cdkDeploy.project.addToRolePolicy(NamespacedPolicy.elasticsearch(domainName))
+      cdkDeploy.project.addToRolePolicy(NamespacedPolicy.elasticsearch(namespace))
       cdkDeploy.project.addToRolePolicy(NamespacedPolicy.ssm(targetStack))
       cdkDeploy.project.addToRolePolicy(
         NamespacedPolicy.globals([GlobalActions.Cloudwatch,GlobalActions.ES]))
@@ -75,7 +74,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
     })
 
     // Deploy to Test
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, `test-${props.esDomainName}`)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`)
 
     // Approval
     const approvalTopic = new Topic(this, 'ApprovalTopic')
@@ -94,7 +93,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
     }
 
     // Deploy to Production
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, `prod-${props.esDomainName}`)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`)
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {

--- a/deploy/cdk/lib/namespaced-policy.ts
+++ b/deploy/cdk/lib/namespaced-policy.ts
@@ -271,7 +271,7 @@ export class NamespacedPolicy {
   public static elasticsearch(domain: string): PolicyStatement {
     return new PolicyStatement({
       resources: [
-        Fn.sub('arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/' + domain),
+        Fn.sub('arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/' + domain + '*'),
       ],
       actions: [
         'es:DescribeElasticsearchDomain',

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -39,7 +39,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly createDns: boolean
   readonly testElasticStack: ElasticStack
   readonly prodElasticStack: ElasticStack
-  readonly searchIndex: string
+  readonly searchIndex?: string
 }
 
 export class DeploymentPipelineStack extends cdk.Stack {
@@ -83,7 +83,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           contact: props.contact,
           [`${props.instanceName}:hostnamePrefix`]: hostnamePrefix,
         },
-        environmentVariables: {
+        environmentVariables: props.searchIndex === undefined ? {} : {
           SEARCH_URL: {
             value: esEndpointParamPath,
             type: BuildEnvironmentVariableType.PARAMETER_STORE,

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -1,4 +1,4 @@
-import { BuildSpec, LinuxBuildImage, PipelineProject } from '@aws-cdk/aws-codebuild'
+import { BuildEnvironmentVariableType, BuildSpec, LinuxBuildImage, PipelineProject } from '@aws-cdk/aws-codebuild'
 import codepipeline = require('@aws-cdk/aws-codepipeline')
 import { Artifact } from '@aws-cdk/aws-codepipeline'
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
@@ -11,6 +11,7 @@ import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { FoundationStack } from '../foundation'
 import { NamespacedPolicy, GlobalActions } from '../namespaced-policy'
 import { PipelineS3Sync } from './pipeline-s3-sync'
+import { ElasticStack } from '../elasticsearch'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly contextEnvName: string
@@ -35,8 +36,10 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly hostnamePrefix: string
   readonly buildScriptsDir: string
   readonly buildOutputDir: string
-  readonly elasticSearchDomain: string
   readonly createDns: boolean
+  readonly testElasticStack: ElasticStack
+  readonly prodElasticStack: ElasticStack
+  readonly searchIndex: string
 }
 
 export class DeploymentPipelineStack extends cdk.Stack {
@@ -47,8 +50,9 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const prodStackName = `${props.namespace}-prod-${props.instanceName}`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, buildPath: string, outputArtifact: Artifact, foundationStack: FoundationStack) => {
+    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, buildPath: string, outputArtifact: Artifact, foundationStack: FoundationStack, elasticStack: ElasticStack) => {
       const paramsPath = `/all/static-host/${targetStack}/`
+      const esEndpointParamPath = `/all/stacks/${elasticStack.stackName}/domain-endpoint`
       const cdkDeploy = new CDKPipelineDeploy(this, `${namespace}-deploy`, {
         targetStack,
         dependsOnStacks: [],
@@ -79,6 +83,16 @@ export class DeploymentPipelineStack extends cdk.Stack {
           contact: props.contact,
           [`${props.instanceName}:hostnamePrefix`]: hostnamePrefix,
         },
+        environmentVariables: {
+          SEARCH_URL: {
+            value: esEndpointParamPath,
+            type: BuildEnvironmentVariableType.PARAMETER_STORE,
+          },
+          SEARCH_INDEX: {
+            value: props.searchIndex,
+            type: BuildEnvironmentVariableType.PLAINTEXT,
+          },
+        },
       })
       cdkDeploy.project.addToRolePolicy(new PolicyStatement({
         actions: [
@@ -88,6 +102,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         ],
         resources:[
           cdk.Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter' + paramsPath + '*'),
+          cdk.Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter' + esEndpointParamPath),
         ],
       }))
       cdkDeploy.project.addToRolePolicy(new PolicyStatement({
@@ -109,7 +124,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
       cdkDeploy.project.addToRolePolicy(NamespacedPolicy.lambda(targetStack))
       cdkDeploy.project.addToRolePolicy(NamespacedPolicy.s3(targetStack))
       cdkDeploy.project.addToRolePolicy(NamespacedPolicy.ssm(targetStack))
-      cdkDeploy.project.addToRolePolicy(NamespacedPolicy.elasticsearchInvoke(props.elasticSearchDomain))
+      cdkDeploy.project.addToRolePolicy(NamespacedPolicy.elasticsearchInvoke(elasticStack.domainName))
 
       if (props.createDns) {
         cdkDeploy.project.addToRolePolicy(NamespacedPolicy.route53RecordSet(foundationStack.hostedZone.hostedZoneId))
@@ -144,7 +159,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const testHostnamePrefix = props.hostnamePrefix ? `${props.hostnamePrefix}-test` : testStackName
     const testBuildPath = `$CODEBUILD_SRC_DIR_${appSourceArtifact.artifactName}/${props.buildOutputDir}`
     const testBuildOutput = new Artifact('TestBuild')
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, testBuildPath, testBuildOutput, props.testFoundationStack)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, testBuildPath, testBuildOutput, props.testFoundationStack, props.testElasticStack)
     const s3syncTest = new PipelineS3Sync(this, 'S3SyncTest', {
       targetStack: testStackName,
       inputBuildArtifact: testBuildOutput,
@@ -194,7 +209,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const prodHostnamePrefix = props.hostnamePrefix ? props.hostnamePrefix : `${props.namespace}-${props.instanceName}`
     const prodBuildPath = `$CODEBUILD_SRC_DIR_${appSourceArtifact.artifactName}/${props.buildOutputDir}`
     const prodBuildOutput = new Artifact('ProdBuild')
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, prodHostnamePrefix, prodBuildPath, prodBuildOutput, props.prodFoundationStack)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, prodHostnamePrefix, prodBuildPath, prodBuildOutput, props.prodFoundationStack, props.prodElasticStack)
     const s3syncProd = new PipelineS3Sync(this, 'S3SyncProd', {
       targetStack: prodStackName,
       inputBuildArtifact: prodBuildOutput,


### PR DESCRIPTION
This further automates deployment by sharing the ES endpoint and index
name with the rest of the app. The endpoint will now be added to ssm
by the elasticsearch stack, which will be injected into the env of
the website CodeBuild as SEARCH_URL. This alleviates the need to manually
create the `/all/static-host/marble-test-website/search_index` and
`/all/static-host/marble-test-website/search_url` parameters.