### PR TITLE
Shared pipeline bucket

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -10,11 +10,17 @@ import manifestPipeline = require('../lib/manifest-pipeline')
 import { getRequiredContext, getContextByNamespace } from '../lib/context-helpers'
 import { ContextEnv } from '../lib/context-env'
 import { Stacks } from '../lib/types'
+import { PipelineFoundationStack } from '../lib/foundation'
 
 export const instantiateStacks = (app: App, namespace: string, contextEnv: ContextEnv, testStacks: Stacks, prodStacks: Stacks): void => {
+  const pipelineFoundationStack = new PipelineFoundationStack(app, `${namespace}-deployment-foundation`, {
+    env: contextEnv.env,
+  })
+
   // Construct common props that are required by all pipeline stacks
   const commonProps = {
     namespace,
+    pipelineFoundationStack,
     testFoundationStack: testStacks.foundationStack,
     prodFoundationStack: prodStacks.foundationStack,
     env: contextEnv.env,

--- a/deploy/cdk/lib/foundation/index.ts
+++ b/deploy/cdk/lib/foundation/index.ts
@@ -1,1 +1,2 @@
 export * from './foundation-stack'
+export * from './pipeline-foundation-stack'

--- a/deploy/cdk/lib/foundation/pipeline-foundation-stack.ts
+++ b/deploy/cdk/lib/foundation/pipeline-foundation-stack.ts
@@ -1,0 +1,14 @@
+import { Construct, Stack, StackProps } from "@aws-cdk/core"
+import { ArtifactBucket } from '@ndlib/ndlib-cdk'
+
+export class PipelineFoundationStack extends Stack {
+  /**
+   * Shared bucket for holding pipeline artifacts
+   */
+  public readonly artifactBucket: ArtifactBucket
+
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props)
+    this.artifactBucket = new ArtifactBucket(this, 'Bucket', {})
+  }
+}

--- a/deploy/cdk/lib/foundation/pipeline-foundation-stack.ts
+++ b/deploy/cdk/lib/foundation/pipeline-foundation-stack.ts
@@ -1,5 +1,6 @@
-import { Construct, Stack, StackProps } from "@aws-cdk/core"
+import { Construct, Stack, StackProps, RemovalPolicy } from "@aws-cdk/core"
 import { ArtifactBucket } from '@ndlib/ndlib-cdk'
+import { BucketEncryption } from "@aws-cdk/aws-s3"
 
 export class PipelineFoundationStack extends Stack {
   /**
@@ -9,6 +10,8 @@ export class PipelineFoundationStack extends Stack {
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
-    this.artifactBucket = new ArtifactBucket(this, 'Bucket', {})
+    this.artifactBucket = new ArtifactBucket(this, 'Bucket', {
+      encryption: BucketEncryption.KMS_MANAGED,
+    })
   }
 }

--- a/deploy/cdk/lib/image-processing/deployment-pipeline.ts
+++ b/deploy/cdk/lib/image-processing/deployment-pipeline.ts
@@ -2,17 +2,16 @@ import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
 import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
-import { Bucket, BucketEncryption } from '@aws-cdk/aws-s3'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
 import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { NamespacedPolicy, GlobalActions } from '../namespaced-policy'
-import { ManifestPipelineStack } from '../manifest-pipeline'
-import { FoundationStack } from '../foundation'
+import { FoundationStack, PipelineFoundationStack } from '../foundation'
 
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
+  readonly pipelineFoundationStack: PipelineFoundationStack
   readonly oauthTokenPath: string;
   readonly namespace: string;
   readonly contextEnvName: string;
@@ -84,11 +83,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
       return cdkDeploy
     }
 
-    const artifactBucket = new Bucket(this, 'artifactBucket', {
-      encryption: BucketEncryption.KMS_MANAGED,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    })
-
     // Source Actions
     const appSourceArtifact = new codepipeline.Artifact('AppCode')
     const appSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -133,7 +127,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {
-      artifactBucket,
+      artifactBucket: props.pipelineFoundationStack.artifactBucket,
       stages: [
         {
           actions: [appSourceAction, infraSourceAction],

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -2,14 +2,15 @@ import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
 import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
-import { Bucket, BucketEncryption } from '@aws-cdk/aws-s3'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
 import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { NamespacedPolicy } from '../namespaced-policy'
+import { PipelineFoundationStack } from '../foundation'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
+  readonly pipelineFoundationStack: PipelineFoundationStack
   readonly oauthTokenPath: string; // Note:  This is a secretstore value, not an ssm value /esu/github/ndlib-git
   readonly appRepoOwner: string;
   readonly appRepoName: string;
@@ -169,11 +170,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
       return cdkDeploy
     }
 
-    const artifactBucket = new Bucket(this, 'artifactBucket', {
-      encryption: BucketEncryption.KMS_MANAGED,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    })
-
     // Source Actions
     const appSourceArtifact = new codepipeline.Artifact('AppCode')
     const appSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -219,7 +215,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {
-      artifactBucket,
+      artifactBucket: props.pipelineFoundationStack.artifactBucket,
       stages: [
         {
           actions: [appSourceAction, infraSourceAction],

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -6,14 +6,15 @@ import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
-import { ArtifactBucket, PipelineNotifications, SlackApproval } from '@ndlib/ndlib-cdk'
+import { PipelineNotifications, SlackApproval } from '@ndlib/ndlib-cdk'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
-import { FoundationStack } from '../foundation'
+import { FoundationStack, PipelineFoundationStack } from '../foundation'
 import { NamespacedPolicy, GlobalActions } from '../namespaced-policy'
 import { PipelineS3Sync } from './pipeline-s3-sync'
 import { ElasticStack } from '../elasticsearch'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
+  readonly pipelineFoundationStack: PipelineFoundationStack
   readonly contextEnvName: string
   readonly oauthTokenPath: string
   readonly appRepoOwner: string
@@ -133,8 +134,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
       return cdkDeploy
     }
 
-    const artifactBucket = new ArtifactBucket(this, 'ArtifactBucket', {})
-
     // Source Actions
     const appSourceArtifact = new codepipeline.Artifact('AppCode')
     const appSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -241,7 +240,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {
-      artifactBucket,
+      artifactBucket: props.pipelineFoundationStack.artifactBucket,
       stages: [
         {
           actions: [appSourceAction, infraSourceAction],

--- a/deploy/cdk/lib/user-content/deployment-pipeline.ts
+++ b/deploy/cdk/lib/user-content/deployment-pipeline.ts
@@ -3,15 +3,15 @@ import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
 import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
-import { Bucket, BucketEncryption } from '@aws-cdk/aws-s3'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
 import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { NamespacedPolicy } from '../namespaced-policy'
-import { FoundationStack } from '../foundation'
+import { FoundationStack, PipelineFoundationStack } from '../foundation'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
+  readonly pipelineFoundationStack: PipelineFoundationStack
   readonly oauthTokenPath: string;
   readonly appRepoOwner: string;
   readonly appRepoName: string;
@@ -86,11 +86,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
       }
       return cdkDeploy
     }
-
-    const artifactBucket = new Bucket(this, 'artifactBucket', {
-      encryption: BucketEncryption.KMS_MANAGED,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    })
 
     // Source Actions
     const appSourceArtifact = new codepipeline.Artifact('AppCode')
@@ -182,7 +177,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {
-      artifactBucket,
+      artifactBucket: props.pipelineFoundationStack.artifactBucket,
       stages: [
         {
           actions: [appSourceAction, infraSourceAction],


### PR DESCRIPTION
To limit the number of buckets, added a pipeline foundation stack that
creates a shared artifact bucket and changed all pipelines to use the
shared bucket.