### PR TITLE
Change stack names to deploy in parallel

### DIFF
--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -28,7 +28,7 @@
   "projectName": "marble",
   "description": "Infrastructure for Marble project",
   "oauthTokenPath": "/all/github/ndlib-git",
-  "namespace": "marble",
+  "namespace": "marbleb",
   "stackType": "service",
   "infraRepoOwner": "ndlib",
   "infraRepoName": "marble-blueprints",


### PR DESCRIPTION
We are aiming to deploy all of these cdk stacks prior to destroying the
old stacks that were created by cloudformation. The only way to do this
is to use a different set of stack names. Changing the default namespace
to `marbleb` to allow for this.