### PR TITLE
Fix issue with permissions for cname change

### DIFF
--- a/deploy/cdk/lib/namespaced-policy.ts
+++ b/deploy/cdk/lib/namespaced-policy.ts
@@ -115,6 +115,7 @@ export class NamespacedPolicy {
         Fn.sub('arn:aws:apigateway:${AWS::Region}::/restapis/*'),
         Fn.sub('arn:aws:apigateway:${AWS::Region}::/domainnames/*'),
         Fn.sub('arn:aws:apigateway:${AWS::Region}::/domainnames'),
+        Fn.sub('arn:aws:apigateway:${AWS::Region}::/tags/*'),
       ],
       actions: [
         'apigateway:*',
@@ -128,7 +129,6 @@ export class NamespacedPolicy {
         Fn.sub('arn:aws:apigateway:${AWS::Region}::/domainnames'),
         Fn.sub('arn:aws:apigateway:${AWS::Region}::/domainnames/${domainName}', { domainName }),
         Fn.sub('arn:aws:apigateway:${AWS::Region}::/domainnames/${domainName}/*', { domainName }),
-        Fn.sub('arn:aws:apigateway:${AWS::Region}::/tags/arn%3Aaws%3Aapigateway%3A${AWS::Region}%3A%3A%2Fdomainnames%2F${domainName}', { domainName }),
       ],
       actions: [
         'apigateway:POST',


### PR DESCRIPTION
Opening up this tags permissions. Was causing problems during the change
of the cnames for the APIs