### PR TITLE
Change dev to use polling instead of webhooks

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -28,6 +28,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     createDns: contextEnv.createDns,
     slackNotifyStackName: contextEnv.slackNotifyStackName,
     notificationReceivers: contextEnv.notificationReceivers,
+    createGithubWebhooks: contextEnv.createGithubWebhooks,
     owner: getRequiredContext(app.node, 'owner'),
     contact: getRequiredContext(app.node, 'contact'),
     oauthTokenPath: getRequiredContext(app.node, 'oauthTokenPath'),

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -8,7 +8,8 @@
       "domainName": "libraries.nd.edu",
       "useExistingDnsZone": true,
       "slackNotifyStackName": "slack-cd-approvals-test-notifier",
-      "rBSCS3ImageBucketName": "rbsc-test-files"
+      "rBSCS3ImageBucketName": "rbsc-test-files",
+      "createGithubWebhooks": false
     },
     "prod": {
       "account": "230391840102",
@@ -19,7 +20,8 @@
       "useExistingDnsZone": false,
       "slackNotifyStackName": "slack-approval-bot-marble-notifier",
       "notificationReceivers": "hl-mellon-deployment-approvers-list@nd.edu",
-      "rBSCS3ImageBucketName": "libnd-smb-rbsc"
+      "rBSCS3ImageBucketName": "libnd-smb-rbsc",
+      "createGithubWebhooks": true
     }
   },
 

--- a/deploy/cdk/lib/context-env.ts
+++ b/deploy/cdk/lib/context-env.ts
@@ -1,6 +1,6 @@
-import { Environment } from "@aws-cdk/cx-api";
-import { ConstructNode } from "@aws-cdk/core";
-import { getRequiredContext } from "./context-helpers";
+import { Environment } from "@aws-cdk/cx-api"
+import { ConstructNode } from "@aws-cdk/core"
+import { getRequiredContext } from "./context-helpers"
 
 export class ContextEnv {
   readonly name: string
@@ -12,7 +12,7 @@ export class ContextEnv {
   readonly slackNotifyStackName: string
   readonly notificationReceivers: string
   readonly rBSCS3ImageBucketName: string
-  readonly createEventRules: boolean
+  readonly createGithubWebhooks: boolean
 
   static fromContext = (node: ConstructNode, name: string): ContextEnv => {
     const contextEnv = getRequiredContext(node, 'environments')[name]

--- a/deploy/cdk/lib/elasticsearch/deployment-pipeline.ts
+++ b/deploy/cdk/lib/elasticsearch/deployment-pipeline.ts
@@ -1,6 +1,6 @@
 import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
-import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
+import { ManualApprovalAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
 import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk'
@@ -19,6 +19,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly infraRepoOwner: string;
   readonly infraRepoName: string;
   readonly infraSourceBranch: string;
+  readonly createGithubWebhooks: boolean;
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
 }
@@ -66,6 +67,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: infraSourceArtifact,
         owner: props.infraRepoOwner,
         repo: props.infraRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
 
     // Deploy to Test

--- a/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
+++ b/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
@@ -5,7 +5,7 @@ import { PolicyStatement } from '@aws-cdk/aws-iam'
 import cdk = require('@aws-cdk/core')
 import { NamespacedPolicy, GlobalActions } from '../namespaced-policy'
 import { Topic } from '@aws-cdk/aws-sns'
-import { ManualApprovalAction, CodeBuildAction } from '@aws-cdk/aws-codepipeline-actions'
+import { ManualApprovalAction, CodeBuildAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
 import { FoundationStack, PipelineFoundationStack } from '../foundation'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { Fn } from '@aws-cdk/core'
@@ -31,6 +31,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly prodFoundationStack: FoundationStack;
   readonly hostnamePrefix: string;
   readonly createDns: boolean;
+  readonly createGithubWebhooks: boolean;
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
 }
@@ -55,6 +56,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: appSourceArtifact,
         owner: props.appRepoOwner,
         repo: props.appRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     const qaSourceArtifact = new codepipeline.Artifact('QACode')
     const qaSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -64,6 +66,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: qaSourceArtifact,
         owner: props.qaRepoOwner,
         repo: props.qaRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
     const infraSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -73,6 +76,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: infraSourceArtifact,
         owner: props.infraRepoOwner,
         repo: props.infraRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline

--- a/deploy/cdk/lib/image-processing/deployment-pipeline.ts
+++ b/deploy/cdk/lib/image-processing/deployment-pipeline.ts
@@ -1,6 +1,6 @@
 import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
-import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
+import { ManualApprovalAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
@@ -28,6 +28,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly infraRepoOwner: string;
   readonly infraRepoName: string;
   readonly infraSourceBranch: string;
+  readonly createGithubWebhooks: boolean;
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
 }
@@ -92,6 +93,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: appSourceArtifact,
         owner: props.appRepoOwner,
         repo: props.appRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
     const infraSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -101,6 +103,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: infraSourceArtifact,
         owner: props.infraRepoOwner,
         repo: props.infraRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
 
     // Deploy to Test

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -1,7 +1,7 @@
 import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
 import { BuildSpec, LinuxBuildImage, PipelineProject, PipelineProjectProps } from '@aws-cdk/aws-codebuild'
-import { ManualApprovalAction, CodeBuildAction } from '@aws-cdk/aws-codepipeline-actions'
+import { ManualApprovalAction, CodeBuildAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
@@ -32,6 +32,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly dataProcessingKeyPath: string;
   readonly prodImageServiceStackName: string;
   readonly prodDataProcessingKeyPath: string;
+  readonly createGithubWebhooks: boolean;
 }
 
 export class DeploymentPipelineStack extends cdk.Stack {
@@ -179,6 +180,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: appSourceArtifact,
         owner: props.appRepoOwner,
         repo: props.appRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
     const infraSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -188,6 +190,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: infraSourceArtifact,
         owner: props.infraRepoOwner,
         repo: props.infraRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     
     const appUnitTestsProject = new PipelineProject(this, 'AppUnitTests', {

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -2,7 +2,7 @@ import { BuildEnvironmentVariableType, BuildSpec, LinuxBuildImage, PipelineProje
 import codepipeline = require('@aws-cdk/aws-codepipeline')
 import { Artifact } from '@aws-cdk/aws-codepipeline'
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
-import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
+import { ManualApprovalAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
@@ -23,6 +23,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly infraRepoOwner: string
   readonly infraRepoName: string
   readonly infraSourceBranch: string
+  readonly createGithubWebhooks: boolean
   readonly qaSpecPath: string
   readonly namespace: string
   readonly instanceName: string
@@ -143,6 +144,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: appSourceArtifact,
         owner: props.appRepoOwner,
         repo: props.appRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
     const infraSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -152,6 +154,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: infraSourceArtifact,
         owner: props.infraRepoOwner,
         repo: props.infraRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
 
     // Deploy to Test

--- a/deploy/cdk/lib/types.ts
+++ b/deploy/cdk/lib/types.ts
@@ -1,3 +1,6 @@
-import { Stack } from "@aws-cdk/core"
+import { Stack, StackProps } from "@aws-cdk/core"
+import { FoundationStack, PipelineFoundationStack } from "./foundation"
+import { ContextEnv } from "./context-env"
+import { Environment } from "@aws-cdk/cx-api"
 
 export type Stacks = { [key: string]: Stack }

--- a/deploy/cdk/lib/user-content/deployment-pipeline.ts
+++ b/deploy/cdk/lib/user-content/deployment-pipeline.ts
@@ -1,7 +1,7 @@
 import { BuildEnvironmentVariableType, BuildSpec, LinuxBuildImage, PipelineProject } from '@aws-cdk/aws-codebuild'
 import codepipeline = require('@aws-cdk/aws-codepipeline')
 import codepipelineActions = require('@aws-cdk/aws-codepipeline-actions')
-import { ManualApprovalAction } from '@aws-cdk/aws-codepipeline-actions'
+import { ManualApprovalAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
 import { PolicyStatement } from '@aws-cdk/aws-iam'
 import { Topic } from '@aws-cdk/aws-sns'
 import cdk = require('@aws-cdk/core')
@@ -19,6 +19,7 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly infraRepoOwner: string;
   readonly infraRepoName: string;
   readonly infraSourceBranch: string;
+  readonly createGithubWebhooks: boolean;
   readonly namespace: string;
   readonly contextEnvName: string;
   readonly owner: string;
@@ -97,6 +98,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: appSourceArtifact,
         owner: props.appRepoOwner,
         repo: props.appRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
     const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
     const infraSourceAction = new codepipelineActions.GitHubSourceAction({
@@ -106,6 +108,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
         output: infraSourceArtifact,
         owner: props.infraRepoOwner,
         repo: props.infraRepoName,
+        trigger: props.createGithubWebhooks ? GitHubTrigger.WEBHOOK : GitHubTrigger.POLL,
     })
 
     // Deploy to Test


### PR DESCRIPTION
Github has a 20 webhook limit per project. We need to limit webhooks to
production pipelines only. Polling should be sufficient in dev.