### PR TITLE
Fix IIIF Image metrics

### DIFF
--- a/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
+++ b/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
@@ -43,11 +43,13 @@ export interface IIiifApiStackProps extends NestedStackProps {
  */
 class ApiStack extends NestedStack {
   readonly apiName: string
+  readonly apiId: string
 
   constructor(scope: Construct, id: string, props: IIiifApiStackProps) {
     super(scope, id, props)
 
-    this.apiName = `${this.stackName}:ApiName`
+    this.apiName = `${this.stackName}-api`
+    this.apiId = Fn.importValue(`${this.stackName}:ApiId`)
 
     if(!fs.existsSync(`${props.serverlessIiifSrcPath}/src`)) {
       this.node.addError(`Cannot deploy this stack. Asset path not found ${props.serverlessIiifSrcPath}/src`)
@@ -87,14 +89,6 @@ class ApiStack extends NestedStack {
     
     // Cdk makes the name too long to create the LayerName. Just remove this prop and let cloudformation do it
     delete iiifTemplate.template.Resources.Dependencies.Properties.LayerName
-
-    iiifTemplate.template.Outputs.ApiName = {
-      Description: 'API Gateway ID',
-      Value: Fn.ref('IiifApi'),
-      Export: {
-        Name: `${this.stackName}:ApiName`,
-      },
-    }
   }
 }
 


### PR DESCRIPTION
The export from the image api is being interpreted by the metrics stack
as the literal export name instead of importing its resolved value.
Unfortunately, API name can't be easily exported. This value is set to
the literal of 'stackname-api' in the source template (see https://github.com/nulib/serverless-iiif/blob/c21120643e199dbf4b342ba1427dd4aab7e11ea6/template.yml#L107).
Changed the stack to share this as the same literal. Also removed it as
an export since this is available at synth time.

Additionally, the source template has an existing export for ApiId at (see https://github.com/nulib/serverless-iiif/blob/c21120643e199dbf4b342ba1427dd4aab7e11ea6/template.yml#L387)
so added an exposed property where when used will import this value from
the api stack.