### PR TITLE
bump memory from 512 to 1024

### DIFF
--- a/deploy/cdk/lib/image-processing/images-stack.ts
+++ b/deploy/cdk/lib/image-processing/images-stack.ts
@@ -113,7 +113,7 @@ export class ImagesStack extends cdk.Stack {
     }
     taskDef.addContainer("AppContainer", {
       image: ecs.ContainerImage.fromAsset(props.dockerfilePath),
-      memoryLimitMiB: 512,
+      memoryLimitMiB: 1024,
       logging,
       environment: {
         LEVEL0: 'enable',


### PR DESCRIPTION
Attempting to resolve out of memory error - STOPPED (OutOfMemoryError: Container killed due to memory usage)