### PR TITLE
update error codes in cloud front

### DIFF
--- a/deploy/cdk/lib/static-host/static-host-stack.ts
+++ b/deploy/cdk/lib/static-host/static-host-stack.ts
@@ -69,7 +69,14 @@ export class StaticHostStack extends cdk.Stack {
         {
           errorCode: 403,
           responseCode: 404,
-          responsePagePath: '/404.html',
+          responsePagePath: '/404.html/index.html',
+          errorCachingMinTtl: 300,
+        },
+        {
+          errorCode: 404,
+          responseCode: 404,
+          responsePagePath: '/404.html/index.html',
+          errorCachingMinTtl: 300,
         },
       ],
       loggingConfig: {


### PR DESCRIPTION
Fixed the 403 error code and added a new one for 404.  

This fixes 404 error problems and fixes the problems we were having with dynamic routes not rendering. 

As a note:  
Dynamic routes are reporting themselves as 404s to fix this we would need to do edge lambda work.  My guess is that this is ok until we need to index in a search engine dynamic content on the site.  