### PR TITLE
Fix Search API SLOs

### DIFF
--- a/deploy/cdk/README.md
+++ b/deploy/cdk/README.md
@@ -52,6 +52,14 @@ It is recommended you run this as a diff to review the changes prior to redeploy
 
 `cdk diff -c env=prod -c stackType=pipeline  marble*deployment`
 
+Once all pipelines have fully deployed to production, deploy the service levels stack to monitor the production stacks:
+
+```sh
+npm run cdk deploy -- --exclusively marbleb-prod-service-levels \
+  -c "namespace=marbleb-prod" \
+  -c "env=prod"
+```
+
 ## Context overrides
 
 There are a number of context values that can be overridden on the cli at deploy time that will change how and where the stacks are deployed.

--- a/deploy/cdk/package.json
+++ b/deploy/cdk/package.json
@@ -47,7 +47,7 @@
     "@aws-cdk/aws-stepfunctions-tasks": "^1.83.0",
     "@aws-cdk/core": "^1.83.0",
     "@aws-cdk/custom-resources": "^1.83.0",
-    "@ndlib/ndlib-cdk": "^1.5.0",
+    "@ndlib/ndlib-cdk": "^1.6.0",
     "@types/source-map-support": "^0.5.2",
     "constructs": "^3.2.99",
     "leaked-handles": "^5.2.0",

--- a/deploy/cdk/yarn.lock
+++ b/deploy/cdk/yarn.lock
@@ -1347,10 +1347,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ndlib/ndlib-cdk@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@ndlib/ndlib-cdk/-/ndlib-cdk-1.5.0.tgz#adcf093b3070a90f1c654b3c5d2c2860e9209c8c"
-  integrity sha512-zwssHQOxvkYcLkDrJP3/Dv9WyFOJ6oHD8fq9cLABPfGdNOtonc4BjKt2mJSP6riDbIGF3uewln0Jcvo3G7O1VA==
+"@ndlib/ndlib-cdk@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@ndlib/ndlib-cdk/-/ndlib-cdk-1.6.0.tgz#505d5a0ec645325b5e35c48d9b2ed9a534fc10a8"
+  integrity sha512-ItvtR8oGUueyOeFU1mq+yI2v7VLK0aCzk1Ypb70psCJULakJrazNecP+TumbqQ8k56Zyd8DjtvR7Hqkq4eoMrA==
   dependencies:
     "@aws-cdk/aws-cloudformation" "^1.45.0"
     "@aws-cdk/aws-cloudwatch" "^1.45.0"


### PR DESCRIPTION
This bumps the version of the ndlib-cdk module to pull in a fix to the
calculation of availability for Elasticsearch. Also added instructions
to the readme on how to deploy the SLO stack.