### PR TITLE
Marble 1357 update maintain metadata

### DIFF
--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -75,6 +75,9 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'appsync:CreateApiKey',
           'appsync:UpdateApiKey',
           'appsync:CreateFunction',
+          'appsync:DeleteResolver',
+          'appsync:DeleteApiKey',
+          'appsync:DeleteFunction',
         ],
         resources: [
           cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:*'),

--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -74,6 +74,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'appsync:CreateResolver',
           'appsync:CreateApiKey',
           'appsync:UpdateApiKey',
+          'appsync:CreateFunction',
         ],
         resources: [
           cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:*'),

--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -78,6 +78,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'appsync:DeleteResolver',
           'appsync:DeleteApiKey',
           'appsync:DeleteFunction',
+          'appsync:GetFunction',
         ],
         resources: [
           cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:*'),

--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -91,13 +91,17 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'appsync:ListTagsForResource',
           'appsync:UntagResource',
           'appsync:UpdateGraphqlApi',
+          'appsync:DeleteGraphqlApi',
         ],
         resources: [
           cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:apis/*'),
         ],
       }))
       cdkDeploy.project.addToRolePolicy(new PolicyStatement({
-        actions: ['appsync:CreateDataSource'],
+        actions: [
+          'appsync:CreateDataSource',
+          'appsync:DeleteDataSource',
+        ],
         resources: [
           cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:/createdatasource'),
         ],


### PR DESCRIPTION
Added permissions to allow maintain-metadata-deployment stack to correctly deploy the maintain-metadata stack