### PR TITLE
Update to allow avif images to be sent from the site.

### DIFF
--- a/src/unifiedEdgeLambda/handler.js
+++ b/src/unifiedEdgeLambda/handler.js
@@ -10,7 +10,7 @@ exports.handler = (event, context, callback) => {
 
   // this is not the best way that this we may need to do an s3 head request to fully
   // detect if the file exists.
-  let valid_extensions = ['.html', '.js', '.json', '.css', '.jpg', '.jpeg', '.png', '.ico', '.map', '.txt', '.kml', '.svg', '.webmanifest', '.webp', '.xml', '.zip']
+  let valid_extensions = ['.html', '.js', '.json', '.css', '.jpg', '.jpeg', '.png', '.ico', '.map', '.txt', '.kml', '.svg', '.webmanifest', '.webp', '.xml', '.zip', '.avif']
   // if there is no extension or it is not in one of the extensions we expect to find on the
   // server.
   if (parsedPath.ext == '' || !valid_extensions.includes(parsedPath.ext)) {

--- a/src/unifiedEdgeLambda/handler.test.js
+++ b/src/unifiedEdgeLambda/handler.test.js
@@ -34,6 +34,7 @@ describe('URL ReWrites', () => {
     { test_uri: '/sub.path', expected_uri: '/sub.path/index.html' },
     { test_uri: '/1999.024', expected_uri: '/1999.024/index.html' },
     { test_uri: '/1239.024.534', expected_uri: '/1239.024.534/index.html' },
+    { test_uri: '/image.avif', expected_uri: '/image.avif' },
   ]
 
   // Loop through each of the test URIs and make sure the function under test rewrites


### PR DESCRIPTION
The updates to gatsby-plugin-image now can generate .avif images along side of webp images for images sets that browsers can choose from when rendering.  

Add the extension in so that they are able to be sent from the site. 

