### PR TITLE
update the edge lambda to route dynamic paths correctly

### DIFF
--- a/src/unifiedEdgeLambda/handler.js
+++ b/src/unifiedEdgeLambda/handler.js
@@ -8,9 +8,16 @@ exports.handler = (event, context, callback) => {
   const parsedPath = path.parse(request.uri);
   let newUri;
 
+  const dynamicPaths = ['user', 'myportfolio'];
+  if (dynamicPaths.includes(parsedPath.dir.split('/')[1])) {
+    newUri = '/index.html';
+    request.uri = newUri;
+    return callback(null, request);
+  }
+
   // this is not the best way that this we may need to do an s3 head request to fully
   // detect if the file exists.
-  let valid_extensions = ['.html', '.js', '.json', '.css', '.jpg', '.jpeg', '.png', '.ico', '.map', '.txt', '.kml', '.svg', '.webmanifest', '.webp', '.xml', '.zip', '.avif']
+  const valid_extensions = ['.html', '.js', '.json', '.css', '.jpg', '.jpeg', '.png', '.ico', '.map', '.txt', '.kml', '.svg', '.webmanifest', '.webp', '.xml', '.zip', '.avif'];
   // if there is no extension or it is not in one of the extensions we expect to find on the
   // server.
   if (parsedPath.ext == '' || !valid_extensions.includes(parsedPath.ext)) {

--- a/src/unifiedEdgeLambda/handler.test.js
+++ b/src/unifiedEdgeLambda/handler.test.js
@@ -35,6 +35,8 @@ describe('URL ReWrites', () => {
     { test_uri: '/1999.024', expected_uri: '/1999.024/index.html' },
     { test_uri: '/1239.024.534', expected_uri: '/1239.024.534/index.html' },
     { test_uri: '/image.avif', expected_uri: '/image.avif' },
+    { test_uri: '/user/jhartzle', expected_uri: '/index.html' },
+    { test_uri: '/myportfolio/blabasldfasgw-werw', expected_uri: '/index.html' },
   ]
 
   // Loop through each of the test URIs and make sure the function under test rewrites


### PR DESCRIPTION
The problem currently is that we have some dynamic routes and they are not getting routed to a file with the built site in it 

This solution checks for those routes and redirects to the root index file in the site. 

This solution is not configurable for any site to dynamically injecting its own dynamic routes.  
However,  since marble is the only site that has dynamic routes and it is the only site at the moment I know will have them.  We don't want to do more work than is required until we know what that work is.  