### PR TITLE
Fix Rule Privilege

### DIFF
--- a/deploy/cdk/lib/namespaced-policy.ts
+++ b/deploy/cdk/lib/namespaced-policy.ts
@@ -87,8 +87,10 @@ export class NamespacedPolicy {
   }
 
   public static iamInstanceProfile(stackName: string): PolicyStatement  {
+    // CDK truncates stack name for auto-created roles
+    const prefix = stackName.substring(0, 25)
     return new PolicyStatement({
-      resources: [ Fn.sub('arn:aws:iam::${AWS::AccountId}:instance-profile/' + stackName + '*') ],
+      resources: [ Fn.sub('arn:aws:iam::${AWS::AccountId}:instance-profile/' + prefix + '*') ],
       actions: ['iam:CreateInstanceProfile', 'iam:AddRoleToInstanceProfile'],
     })
   }
@@ -140,8 +142,10 @@ export class NamespacedPolicy {
   }
 
   public static s3(stackName: string): PolicyStatement {
+    // CDK truncates stack name for auto-created roles
+    const prefix = stackName.substring(0, 25)
     return new PolicyStatement({
-      resources: [ Fn.sub('arn:aws:s3:::' + stackName + '*') ],
+      resources: [ Fn.sub('arn:aws:s3:::' + prefix + '*') ],
       actions: ['s3:*'],
     })
   }
@@ -179,8 +183,10 @@ export class NamespacedPolicy {
   }
 
   public static dynamodb(stackName: string): PolicyStatement  {
+    // CDK truncates stack name for auto-created roles
+    const prefix = stackName.substring(0, 25)
     return new PolicyStatement({
-      resources: [ Fn.sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/' + stackName + '*') ],
+      resources: [ Fn.sub('arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/' + prefix + '*') ],
       actions: [
         'dynamodb:CreateBackup',
         'dynamodb:CreateTable',
@@ -231,9 +237,11 @@ export class NamespacedPolicy {
   }
 
   public static events(stackName: string): PolicyStatement  {
+    // CDK truncates stack name for auto-created functions
+    const prefix = stackName.substring(0, 25)
     return new PolicyStatement({
       resources: [
-        Fn.sub('arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/' + stackName + '*'),
+        Fn.sub('arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/' + prefix + '*'),
       ],
       actions: [
         'events:PutEvents',

--- a/deploy/cdk/lib/namespaced-policy.ts
+++ b/deploy/cdk/lib/namespaced-policy.ts
@@ -222,10 +222,12 @@ export class NamespacedPolicy {
   }
 
   public static autoscale(stackName: string): PolicyStatement  {
+    // CDK truncates stack name for auto-created functions
+    const prefix = stackName.substring(0, 25)
     return new PolicyStatement({
       resources: [
-        Fn.sub('arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:launchConfiguration:*:launchConfigurationName/' + stackName + '*'),
-        Fn.sub('arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/' + stackName + '*'),
+        Fn.sub('arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:launchConfiguration:*:launchConfigurationName/' + prefix + '*'),
+        Fn.sub('arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/' + prefix + '*'),
       ],
       actions: [
         'autoscaling:CreateAutoScalingGroup',
@@ -257,9 +259,11 @@ export class NamespacedPolicy {
   }
 
   public static sns(stackName: string): PolicyStatement  {
+    // CDK truncates stack name for auto-created functions
+    const prefix = stackName.substring(0, 25)
     return new PolicyStatement({
       resources: [
-        Fn.sub('arn:aws:sns:${AWS::Region}:${AWS::AccountId}:' + stackName + '*'),
+        Fn.sub('arn:aws:sns:${AWS::Region}:${AWS::AccountId}:' + prefix + '*'),
       ],
       actions: [
         'sns:CreateTopic',


### PR DESCRIPTION
* ARNs will have the stackName truncated if the stackName plus logicalId gets too long.  I'm truncating the stack name to 25 characters to accommodate abbreviated stack name in some ARNs.