### PR TITLE
Add stack for hosting audio and video content.

### DIFF
--- a/deploy/cdk/README.md
+++ b/deploy/cdk/README.md
@@ -35,6 +35,7 @@ marble-foundation
 marble-image-processing
 marble-image-service
 marble-manifest
+marble-multimedia-assets
 marble-redbox
 marble-user-content
 marble-website

--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -9,6 +9,7 @@ import elasticsearch = require('../lib/elasticsearch')
 import staticHost = require('../lib/static-host')
 import manifestPipeline = require('../lib/manifest-pipeline')
 import maintainMetadata = require('../lib/maintain-metadata')
+import multimediaAssets = require('../lib/multimedia-assets')
 import { getContextByNamespace } from '../lib/context-helpers'
 import { ContextEnv } from '../lib/context-env'
 import { Stacks } from '../lib/types'
@@ -109,6 +110,13 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     ...imageProcessingContext,
   })
 
+  const multimediaAssetsContext = getContextByNamespace('multimediaAssets')
+  const multimediaAssetsStack = new multimediaAssets.MultimediaAssetsStack(app, `${namespace}-multimedia-assets`, {
+    foundationStack,
+    ...commonProps,
+    ...multimediaAssetsContext,
+  })
+
   const services = {
     foundationStack,
     website,
@@ -121,6 +129,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     elasticSearchStack,
     manifestPipelineStack,
     maintainMetadataStack,
+    multimediaAssetsStack,
   }
 
   const slos = [

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -135,6 +135,8 @@
 
   "maintainMetadata:openIdConnectProvider": "https://okta.nd.edu/oauth2/ausxosq06SDdaFNMB356",
 
+  "multimediaAssets:cacheTtl": 86400,
+
   "slos:emailSubscriber": "rfox2@nd.edu",
   "slos:sloDocLink": "https://docs.google.com/document/d/1AZGtz4es6fPMPzgkJuDOL0RDULFpy97emeKMPFYxyCA/edit",
   "slos:runbookLink": "https://github.com/ndlib/TechnologistsPlaybook/tree/master/run-books",

--- a/deploy/cdk/lib/multimedia-assets/index.ts
+++ b/deploy/cdk/lib/multimedia-assets/index.ts
@@ -1,0 +1,1 @@
+export * from './multimedia-assets-stack'

--- a/deploy/cdk/lib/multimedia-assets/multimedia-assets-stack.ts
+++ b/deploy/cdk/lib/multimedia-assets/multimedia-assets-stack.ts
@@ -1,0 +1,137 @@
+import {
+  CloudFrontAllowedMethods,
+  CloudFrontWebDistribution,
+  OriginAccessIdentity,
+  ViewerCertificate,
+  ViewerProtocolPolicy,
+} from '@aws-cdk/aws-cloudfront'
+import { PolicyStatement, Effect, CanonicalUserPrincipal } from '@aws-cdk/aws-iam'
+import { CnameRecord } from '@aws-cdk/aws-route53'
+import { Bucket, IBucket, BlockPublicAccess, HttpMethods } from '@aws-cdk/aws-s3'
+import * as cdk from '@aws-cdk/core'
+import { FoundationStack } from '../foundation/foundation-stack'
+
+export interface IMultimediaAssetsStackProps extends cdk.StackProps {
+  /**
+   * Foundation stack which provides the log bucket and certificate to use.
+   */
+  readonly foundationStack: FoundationStack
+
+  /**
+   * The domain where assets will be hosted.
+   */
+  readonly domainName: string
+
+  /**
+   * If true, will create record in Route53 for the CNAME
+   */
+  readonly createDns: boolean
+
+  /**
+   * The namespace used for naming stacks and resources.
+   */
+  readonly namespace: string
+
+  /**
+   * Subdomain to host the site at. If not provided, will use <namespace>-multimedia
+   */
+  readonly hostnamePrefix?: string
+
+  /**
+   * How long to cache origin responses (in seconds).
+   */
+  readonly cacheTtl: number
+}
+
+export class MultimediaAssetsStack extends cdk.Stack {
+  /**
+   * Audio and video files go here. The bucket is not public, but the CloudFront will treat them as public for now.
+   * Some may be private later with a lambda authorizer.
+   */
+  public readonly multimediaBucket: IBucket
+
+  /**
+   * The cloudfront distribution.
+   */
+  public readonly cloudfront: CloudFrontWebDistribution
+
+  /**
+   * The full domain name where the cloudfront will be available from.
+   */
+  public readonly hostname: string
+
+  constructor(scope: cdk.Construct, id: string, props: IMultimediaAssetsStackProps) {
+    super(scope, id, props)
+
+    const prefix = props.hostnamePrefix || `${props.namespace}-multimedia`
+    this.hostname = `${prefix}.${props.foundationStack.hostedZone.zoneName}`
+
+    this.multimediaBucket = new Bucket(this, 'MultimediaBucket', {
+      bucketName: `${prefix}-${this.account}`, // Bucket names must be unique, so account id helps ensure that
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      cors: [
+        {
+          allowedHeaders: ['*'],
+          allowedMethods: [HttpMethods.GET],
+          allowedOrigins: [ `*.${props.domainName}`],
+          maxAge: 3600,
+        },
+      ],
+      serverAccessLogsBucket: props.foundationStack.logBucket,
+      serverAccessLogsPrefix: 's3/data-broker/',
+    })
+
+    const oai = new OriginAccessIdentity(this, 'OriginAccessIdentity', {
+      comment: `OAI for ${this.stackName}`,
+    })
+    this.multimediaBucket.addToResourcePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['s3:GetBucket*', 's3:List*', 's3:GetObject*'],
+        resources: [this.multimediaBucket.bucketArn, this.multimediaBucket.bucketArn + '/*'],
+        principals: [new CanonicalUserPrincipal(oai.cloudFrontOriginAccessIdentityS3CanonicalUserId)],
+      }),
+    )
+
+    this.cloudfront = new CloudFrontWebDistribution(this, 'Distribution', {
+      comment: this.hostname,
+      loggingConfig: {
+        bucket: props.foundationStack.logBucket,
+        includeCookies: true,
+        prefix: `web/${this.hostname}/`,
+      },
+      originConfigs: [
+        {
+          s3OriginSource: {
+            s3BucketSource: this.multimediaBucket,
+            originAccessIdentity: oai,
+          },
+          behaviors: [
+            {
+              isDefaultBehavior: true,
+              allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+              compress: true,
+              defaultTtl: cdk.Duration.seconds(props.cacheTtl),
+            }
+          ],
+        },
+      ],
+      viewerCertificate: ViewerCertificate.fromAcmCertificate(props.foundationStack.certificate, {
+        aliases: [this.hostname],
+      }),
+      viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+    })
+
+    if (props.createDns) {
+      new CnameRecord(this, 'MultimediaAssetsCnameRecord', {
+        recordName: this.hostname,
+        comment: this.hostname,
+        domainName: this.cloudfront.distributionDomainName,
+        zone: props.foundationStack.hostedZone,
+        ttl: cdk.Duration.minutes(15),
+      })
+    }
+  }
+}

--- a/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
+++ b/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
@@ -1,0 +1,101 @@
+import { expect as expectCDK, haveResourceLike, stringLike } from '@aws-cdk/assert'
+import cdk = require('@aws-cdk/core')
+import { FoundationStack } from '../../lib/foundation'
+import { MultimediaAssetsStack } from '../../lib/multimedia-assets'
+
+describe('MultimediaAssetsStack', () => {
+  const env = {
+    account: '123456789',
+    region: 'us-east-1',
+  }
+  const domainName = 'fake.domain'
+
+  const app = new cdk.App()
+  const foundationStack = new FoundationStack(app, 'FoundationStack', {
+    env,
+    domainName,
+  })
+  const stack = new MultimediaAssetsStack(app, 'TestStack', {
+    env,
+    foundationStack,
+    domainName,
+    createDns: true,
+    namespace: 'my-happy-place',
+    cacheTtl: 9001,
+    stackName: 'test-stack-name',
+  })
+
+  test('creates an s3 bucket for assets', () => {
+    expectCDK(stack).to(
+      haveResourceLike('AWS::S3::Bucket', {
+        BucketName: 'my-happy-place-multimedia-123456789',
+        CorsConfiguration: {
+          CorsRules: [
+            {
+              AllowedHeaders: [
+                '*',
+              ],
+              AllowedMethods: [
+                'GET',
+              ],
+              AllowedOrigins: [
+                '*.fake.domain',
+              ],
+              MaxAge: 3600,
+            }
+          ]
+        },
+        LoggingConfiguration: {
+          DestinationBucketName: {
+            'Fn::ImportValue': stringLike('FoundationStack:ExportsOutputRefLogBucket*'),
+          },
+          LogFilePrefix: 's3/data-broker/',
+        },
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        },
+      }),
+    )
+  })
+
+  test('creates a cloudfront with an appropriate domain name', () => {
+    expectCDK(stack).to(
+      haveResourceLike('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          Aliases: [
+            'my-happy-place-multimedia.fake.domain',
+          ],
+          DefaultCacheBehavior: {
+            DefaultTTL: 9001,
+            ViewerProtocolPolicy: 'redirect-to-https',
+          },
+          ViewerCertificate: {
+            AcmCertificateArn: {
+              'Fn::ImportValue': stringLike('FoundationStack:ExportsOutputRefCertificate*'),
+            },
+          },
+        },
+      }),
+    )
+  })
+
+  test('creates a route53 record for the domain', () => {
+    expectCDK(stack).to(
+      haveResourceLike('AWS::Route53::RecordSet', {
+        Name: 'my-happy-place-multimedia.fake.domain.',
+        Type: 'CNAME',
+        HostedZoneId: {
+          'Fn::ImportValue': stringLike('FoundationStack:ExportsOutputRefHostedZone*'),
+        },
+        ResourceRecords: [
+          {
+            'Fn::GetAtt': ['DistributionCFDistribution882A7313', 'DomainName'],
+          },
+        ],
+      }),
+    )
+  })
+})


### PR DESCRIPTION
This creates a simple s3 bucket and a CloudFront. Public access to the s3 bucket is blocked, so they must be accessed through the CloudFront. CORS headers restrict access to the same domain as the cloudfront CNAME.

I didn't write a pipeline for this yet for a few reasons:

- We may only want one bucket to share between test and prod, similar to how the rbsc bucket is set up. (Not 100% sure on this.)
- We don't have a place to fetch content _from_ and put it in the bucket, so there wouldn't really be anything for the pipeline to monitor for changes. Sure, it could redeploy changes to the stack itself, but that sort of leads into the next one...
- Maybe this could be folded into another stack, like image-processing? It stands to reason that all assets (images/video/audio) would share infrastructure, but we do have some special tasks that apply to images right now. It would also require a rename of that stack to be more general, so I went with a less-invasive approach that keeps the stacks independent.

Example of accessing media from this stack:
https://viewer-iiif.library.nd.edu/marble/?manifest=https://mlk-multimedia.libraries.nd.edu/sampleVideo/manifest.json