### PR TITLE
Silence User Content API alarms

### DIFF
--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -201,6 +201,10 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
       apiName: userContentStack.apiName,
       sloThreshold: 0.95,
       latencyThreshold: 500,
+      "alarmsEnabled": {
+        "High": false,
+        "Low": false,
+      },
     },
     {
       title: "User Content API",
@@ -208,6 +212,10 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
       apiName: userContentStack .apiName,
       sloThreshold: 0.99,
       latencyThreshold: 2000,
+      "alarmsEnabled": {
+        "High": false,
+        "Low": false,
+      },
     },
     {
       title: "Search API",


### PR DESCRIPTION
This API is being refactored to use AppSync queries instead of an API GW.
We don't have a way to create SLOs using an AppSync SLI yet, so silencing
this until we have that implemented (https://jira.library.nd.edu/browse/ESU-1694)
and the AppSync work is complete (https://jira.library.nd.edu/browse/MARBLE-1665).