### PR TITLE
Bump manifest-lambda resources

### DIFF
--- a/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
+++ b/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
@@ -95,6 +95,7 @@ export class ManifestLambdaStack extends Stack {
         }),
       ],
       timeout: Duration.seconds(90),
+      memorySize: 1024,
     })
 
     const api = new apigateway.RestApi(this, 'IIIFApiGateway', {


### PR DESCRIPTION
* Bumped memory size from default of 128 to 1024 to speed lambda execution from around 3 seconds to around half a second.