### PR TITLE
Fix manifest deployment

### DIFF
--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -79,10 +79,10 @@ export class DeploymentPipelineStack extends cdk.Stack {
           "manifestPipeline:appConfigPath": `/all/stacks/${targetStack}`,
           "manifestPipeline:lambdaCodeRootPath": `$CODEBUILD_SRC_DIR_${appSourceArtifact.artifactName}`,
           "manifestPipeline:hostnamePrefix": hostnamePrefix,
-          "manifestPipeline:createEventRules": createEventRules ? "true" : "",  // Note that any non-empty string will be evaluated as truthy when converting to boolean
+          "manifestPipeline:createEventRules": createEventRules ? "true" : "false",
           "manifestPipeline:metadataTimeToLiveDays": metadataTimeToLiveDays,
           "manifestPipeline:filesTimeToLiveDays": filesTimeToLiveDays,
-          "manifestPipeline:createCopyMediaContentLambda": createCopyMediaContentLambda ? "true" : "",  // Note that any non-empty string will be evaluated as truthy when converting to boolean
+          "manifestPipeline:createCopyMediaContentLambda": createCopyMediaContentLambda ? "true" : "false",
         },
         additionalRuntimeEnvironments: {
           python: '3.8',

--- a/deploy/cdk/lib/manifest-pipeline/manifest-pipeline-stack.ts
+++ b/deploy/cdk/lib/manifest-pipeline/manifest-pipeline-stack.ts
@@ -117,7 +117,6 @@ export interface IBaseStackProps extends StackProps {
 
   /**
    * This will create the CopyMediaContentLambda if true, otherwise it won't.
-   * Note that any non-empty string will be truthy, so the pipeline must pass an empty string for false.
    */
   readonly createCopyMediaContentLambda?: boolean;
 
@@ -457,7 +456,7 @@ export class ManifestPipelineStack extends Stack {
         runtime: Runtime.PYTHON_3_8,
         environment: {
           SENTRY_DSN: props.sentryDsn,
-          FILE_SHARE_ARN: fileShareArn
+          FILE_SHARE_ARN: fileShareArn,
         },
         timeout: Duration.seconds(900),
         initialPolicy: [


### PR DESCRIPTION
* explicitly pass "true" or "false" to createCopyMediaContentLambda, instead of passing an empty string to be coerced to false.