### PR TITLE
Marble 1793 create api gateway for public portfolios

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -57,6 +57,8 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
       prodElasticStack: prodStacks.elasticSearchStack,
       testMaintainMetadataStack: testStacks.maintainMetadataStack,
       prodMaintainMetadataStack: prodStacks.maintainMetadataStack,
+      testManifestLambdaStack: testStacks.manifestLambdaStack,
+      prodManifestLambdaStack: prodStacks.manifestLambdaStack,
       ...commonProps,
       ...staticHostContext,
       ...instanceContext,

--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -123,7 +123,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
   })
 
   const manifestLambdaContext = getContextByNamespace('manifestLambda')
-  const manfiestLambdaStack = new manifestLambda.ManifestLambdaStack(app, `${namespace}-manifest-lambda`, {
+  const manifestLambdaStack = new manifestLambda.ManifestLambdaStack(app, `${namespace}-manifest-lambda`, {
     foundationStack,
     maintainMetadataStack,
     ...commonProps,
@@ -143,7 +143,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     manifestPipelineStack,
     maintainMetadataStack,
     multimediaAssetsStack,
-    manfiestLambdaStack,
+    manifestLambdaStack,
   }
 
   const slos = [
@@ -176,13 +176,13 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     {
       title: "IIIF Manifest API",
       type: "ApiAvailability",
-      apiName: manfiestLambdaStack.apiName,
+      apiName: manifestLambdaStack.apiName,
       sloThreshold: 0.999,
     },
     {
       title: "IIIF Manifest API",
       type: "ApiLatency",
-      apiName: manfiestLambdaStack.apiName,
+      apiName: manifestLambdaStack.apiName,
       sloThreshold: 0.95,
       latencyThreshold: 3000,
     },

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -145,6 +145,7 @@
   "manifestLambda:appRepoOwner": "ndlib",
   "manifestLambda:appRepoName": "marble-manifest-lambda",
   "manifestLambda:appSourceBranch": "master",
+  "manifestLambda:publicGraphqlHostnamePrefix": "public-graphql",
 
   "multimediaAssets:cacheTtl": 86400,
 

--- a/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
+++ b/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
@@ -55,9 +55,9 @@ export interface IBaseStackProps extends StackProps {
 }
 
 export class ManifestLambdaStack extends Stack {
-  readonly apiName: string
-  readonly publicApiName: string
-  readonly publicGraphqlApiKeyPath: string
+  public readonly apiName: string
+  public readonly publicApiName: string
+  public readonly publicGraphqlApiKeyPath: string
 
   constructor(scope: Construct, id: string, props: IBaseStackProps) {
     super(scope, id, props)

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -14,6 +14,7 @@ import { IPipelineS3SyncProps, PipelineS3Sync } from './pipeline-s3-sync'
 import { ElasticStack } from '../elasticsearch'
 import { DockerhubImage } from '../dockerhub-image'
 import { MaintainMetadataStack } from '../maintain-metadata'
+import { ManifestLambdaStack } from '../manifest-lambda'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly pipelineFoundationStack: PipelineFoundationStack
@@ -51,6 +52,8 @@ export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly prodDomainNameOverride?: string
   readonly testMaintainMetadataStack: MaintainMetadataStack
   readonly prodMaintainMetadataStack: MaintainMetadataStack
+  readonly testManifestLambdaStack: ManifestLambdaStack
+  readonly prodManifestLambdaStack: ManifestLambdaStack
 }
 
 export class DeploymentPipelineStack extends cdk.Stack {
@@ -117,6 +120,8 @@ export class DeploymentPipelineStack extends cdk.Stack {
         resources: [
           cdk.Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter' + props.testMaintainMetadataStack.maintainMetadataKeyBase + '*'),
           cdk.Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter' + props.prodMaintainMetadataStack.maintainMetadataKeyBase + '*'),
+          cdk.Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter' + props.testManifestLambdaStack.publicGraphqlApiKeyPath + '*'),
+          cdk.Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter' + props.prodManifestLambdaStack.publicGraphqlApiKeyPath + '*'),
         ],
         actions: ["ssm:Get*"],
       }))
@@ -190,6 +195,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
       elasticSearchDomainName: props.testElasticStack.domainName,
       graphqlApiUrlKeyPath: props.testMaintainMetadataStack.graphqlApiUrlKeyPath,
       graphqlApiKeyKeyPath: props.testMaintainMetadataStack.graphqlApiKeyKeyPath,
+      publicGraphqlApiKeyPath: props.testManifestLambdaStack.publicGraphqlApiKeyPath,
       buildEnvironment: 'test',
       maintainMetadataKeyBase: props.testMaintainMetadataStack.maintainMetadataKeyBase,
     }
@@ -256,6 +262,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
       elasticSearchDomainName: props.prodElasticStack.domainName,
       graphqlApiUrlKeyPath: props.prodMaintainMetadataStack.graphqlApiUrlKeyPath,
       graphqlApiKeyKeyPath: props.prodMaintainMetadataStack.graphqlApiKeyKeyPath,
+      publicGraphqlApiKeyPath: props.prodManifestLambdaStack.publicGraphqlApiKeyPath,
       buildEnvironment: 'production',
       maintainMetadataKeyBase: props.prodMaintainMetadataStack.maintainMetadataKeyBase,
     }

--- a/deploy/cdk/lib/static-host/pipeline-s3-sync.ts
+++ b/deploy/cdk/lib/static-host/pipeline-s3-sync.ts
@@ -46,6 +46,7 @@ export interface IPipelineS3SyncProps extends PipelineProjectProps {  /**
   readonly graphqlApiKeyKeyPath: string
   readonly maintainMetadataKeyBase: string
   readonly buildEnvironment: string
+  readonly publicGraphqlApiKeyPath: string
 }
 
 export class PipelineS3Sync extends Construct {
@@ -114,6 +115,10 @@ export class PipelineS3Sync extends Construct {
         GRAPHQL_KEY_BASE: {
           value: props.maintainMetadataKeyBase,
           type: BuildEnvironmentVariableType.PLAINTEXT,
+        },
+        PUBLIC_GRAPHQL_API_URL: {
+          value: props.publicGraphqlApiKeyPath,
+          type: BuildEnvironmentVariableType.PARAMETER_STORE,
         },
       },
       buildSpec: BuildSpec.fromObject({

--- a/deploy/cdk/package.json
+++ b/deploy/cdk/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
-    "aws-cdk": "1.111.0",
+    "aws-cdk": "^1.113.0",
     "eslint": "^7.27.0",
     "eslint-plugin-jest": "^24.3.6",
     "jest": "^26.6.3",

--- a/deploy/cdk/test/manifest-lambda/smokeTests.json
+++ b/deploy/cdk/test/manifest-lambda/smokeTests.json
@@ -52,7 +52,7 @@
 					"    pm.expect(pm.response.responseTime).to.be.below(parseInt(maxResponseTime));",
 					"});",
 					"pm.test(\"Illegal endpoint status code is 405\", function () {",
-					"    pm.response.to.have.status(405);",
+					"    pm.response.to.have.status(405) || pm.response.to.have.status(403);",
 					"});"
 				]
 			}

--- a/deploy/cdk/test/manifest-lambda/smokeTests.json
+++ b/deploy/cdk/test/manifest-lambda/smokeTests.json
@@ -22,7 +22,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "https://{{hostname}}/query/test",
+					"raw": "https://{{hostname}}",
 					"protocol": "https",
 					"host": [
 						"{{hostname}}"
@@ -51,8 +51,8 @@
 					"pm.test(\"Response time is less than \" + maxResponseTime + \"ms\", function () {",
 					"    pm.expect(pm.response.responseTime).to.be.below(parseInt(maxResponseTime));",
 					"});",
-					"pm.test(\"Illegal endpoint status code is 405\", function () {",
-					"    pm.response.to.have.status(405) || pm.response.to.have.status(403);",
+					"pm.test(\"Forbidden status code is 403 of not passing query parameter\", function () {",
+					"    pm.response.to.have.status(403);",
 					"});"
 				]
 			}

--- a/deploy/cdk/test/manifest-lambda/smokeTests.json
+++ b/deploy/cdk/test/manifest-lambda/smokeTests.json
@@ -1,0 +1,71 @@
+{
+	"info": {
+		"_postman_id": "d693411c-a8ff-4b88-aaf1-a47949804eb8",
+		"name": "Multimedia Assets Smoke Tests",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Website Root",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://{{hostname}}/query/test",
+					"protocol": "https",
+					"host": [
+						"{{hostname}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"var maxResponseTime = pm.variables.get(\"maxResponseTime\");",
+					"pm.test(\"Response time is less than \" + maxResponseTime + \"ms\", function () {",
+					"    pm.expect(pm.response.responseTime).to.be.below(parseInt(maxResponseTime));",
+					"});",
+					"pm.test(\"Illegal endpoint status code is 405\", function () {",
+					"    pm.response.to.have.status(405);",
+					"});"
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "hostname",
+			"value": ""
+		},
+		{
+			"key": "maxResponseTime",
+			"value": "1000"
+		}
+	]
+}

--- a/deploy/cdk/test/manifest-pipeline/stack.test.ts
+++ b/deploy/cdk/test/manifest-pipeline/stack.test.ts
@@ -180,14 +180,6 @@ describe('ManifestPipelineStack', () => {
 
 
   describe('Lambdas', () => {
-    test('creates an SPA Redirection Edge Lambda ', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
-        Handler: "index.handler",
-        Description: `This Lambda will take incoming web requests and adjust the request URI as appropriate.
-        Any directory that does not end with an index.json will have that appended to it.`,
-      }))
-    })
-
     test('creates MuseumExportLambda', () => {
       expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
         Description: 'Creates standard json from web-enabled items from Web Kiosk.',

--- a/deploy/cdk/yarn.lock
+++ b/deploy/cdk/yarn.lock
@@ -811,10 +811,25 @@
   dependencies:
     md5 "^2.3.0"
 
+"@aws-cdk/cfnspec@1.113.0":
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.113.0.tgz#d4e24a8b7de52765ca327a04f80c21976826e8f6"
+  integrity sha512-ty3Ow1UjTZrVRrdj1E6caXOoTw/pSm6sP4kBSUeFqYdPzREMYbwEWnObQtjttQrynizwjWtMkppS/quCvolTrA==
+  dependencies:
+    md5 "^2.3.0"
+
 "@aws-cdk/cloud-assembly-schema@1.111.0":
   version "1.111.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.111.0.tgz#225bdb3cbde6ec13056130de823dcaa2b46f01f0"
   integrity sha512-Ql59HF7PDLQJislHAVhTZE8JHUtb5zikCjHseOuvWh3c5f5jjJ4i7pq9N6wjfamjfC7JGQ7LmRSXP61NIc3aNQ==
+  dependencies:
+    jsonschema "^1.4.0"
+    semver "^7.3.5"
+
+"@aws-cdk/cloud-assembly-schema@1.113.0":
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.113.0.tgz#724cf193d5b780da1e5cbe2f9fba8f05750c8ccd"
+  integrity sha512-BE6YplMVhIc/M23pvGZpu8p97Rrn98TYVg5/qYBauglJYD5Y3EtxEgKsLOEgth1UOgw8TsgVV0VpalesUCq3Fg==
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
@@ -825,6 +840,19 @@
   integrity sha512-RSOtqHkUJ9rSpzoUwcMJ8Z/c284np8Ue7nkeUVwaf9V8M37O690r1VCAtsS4ksN730o+ah3Es/kt0wZJttR+Lw==
   dependencies:
     "@aws-cdk/cfnspec" "1.111.0"
+    "@types/node" "^10.17.60"
+    colors "^1.4.0"
+    diff "^5.0.0"
+    fast-deep-equal "^3.1.3"
+    string-width "^4.2.2"
+    table "^6.7.1"
+
+"@aws-cdk/cloudformation-diff@1.113.0":
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.113.0.tgz#52aa7102e0f5d6bb378887f6d05f166311c56e4a"
+  integrity sha512-v0/c5/akXgTAvd5Ilca5xlGZz6qr6Z7zoStJI/gBhVfkTmWrg/b2S4eTTm83HF2w4VCaLSAV4CTA8YyIsGqV0A==
+  dependencies:
+    "@aws-cdk/cfnspec" "1.113.0"
     "@types/node" "^10.17.60"
     colors "^1.4.0"
     diff "^5.0.0"
@@ -868,6 +896,14 @@
     "@aws-cdk/cloud-assembly-schema" "1.111.0"
     semver "^7.3.5"
 
+"@aws-cdk/cx-api@1.113.0":
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.113.0.tgz#542b9aaa1c18e1dff877c6b9aea39d3080271576"
+  integrity sha512-WghmcwPR5I6Vy9RVhKQU8W3irg12YAWpgKrtiCb6Jq5W3WAf0rDWQ9bypyIAp0He+NLgTDdugoRqz7ok1pWfbA==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "1.113.0"
+    semver "^7.3.5"
+
 "@aws-cdk/lambda-layer-awscli@1.111.0":
   version "1.111.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.111.0.tgz#c4c8dc1b2fb16db77479a9a93d112b931383cc66"
@@ -890,6 +926,11 @@
   version "1.111.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.111.0.tgz#26bb113d547629406ca2b1f588b1ed4656df7fcb"
   integrity sha512-xUqNPkg5cEV/df1aSle2cc+yasgyOtFPMXw53PYMTArwfmHMsXb5Lna0lsFddMx4heO+be5XYUrWVijIiPHMIQ==
+
+"@aws-cdk/region-info@1.113.0":
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.113.0.tgz#38fe4dc31004b734c2ba7ba73605fea513a87c90"
+  integrity sha512-Mlmp6DbbKHteBsIRSlfmH2o0uzPG6LWWhqAQNQlDRdsXGlFtisdsKlloxP1HiKRfXiVp/eDatpPGc0BKZyPgcg==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -1892,19 +1933,19 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-cdk@1.111.0:
-  version "1.111.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.111.0.tgz#d880747b9ddd7d23af0f39b1b77183457d71b646"
-  integrity sha512-RUxaIDjJvCfUADVqAJtwJ3XUxWKPurjxbw8oIhannvGmM1w2fIgXSm8Jx1ZN91rYLiBfkLtQMaggwvPP7BH55g==
+aws-cdk@^1.113.0:
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.113.0.tgz#e3cff4f7314c02cc3ec76dd2a61e122f4f0951f0"
+  integrity sha512-wmSJIGiBCcAAk/tZGkE7jMCFYGDG1FuMrE8Gd8X9Q7rt/uhao5yylVeowWuWrkD/bYjRuPUHzNa3m4awMCIKOQ==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.111.0"
-    "@aws-cdk/cloudformation-diff" "1.111.0"
-    "@aws-cdk/cx-api" "1.111.0"
-    "@aws-cdk/region-info" "1.111.0"
+    "@aws-cdk/cloud-assembly-schema" "1.113.0"
+    "@aws-cdk/cloudformation-diff" "1.113.0"
+    "@aws-cdk/cx-api" "1.113.0"
+    "@aws-cdk/region-info" "1.113.0"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     camelcase "^6.2.0"
-    cdk-assets "1.111.0"
+    cdk-assets "1.113.0"
     colors "^1.4.0"
     decamelize "^5.0.0"
     fs-extra "^9.1.0"
@@ -2169,13 +2210,13 @@ case@1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk-assets@1.111.0:
-  version "1.111.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.111.0.tgz#62e51cf7a927070a212ec1dd349de2e1a2c1bcb8"
-  integrity sha512-HYQMFUyP1PWLceQMTh2oCRBDvR/NNaiT0bq012jeFKt6vK6ubJ3713tlrtFqEYPexTJnNSP/8M4LZqKWhPwJCA==
+cdk-assets@1.113.0:
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.113.0.tgz#ecd8f1c3d1027ff6ccf9541bb30471e4b644b6f5"
+  integrity sha512-1Io0aa77/SbMsrweE580ho7VANXzqqxP4aFJuZXEng5iKcfVM7s7Ss6Zet17THjJtq+dGGy7VRK1pavgFfimWg==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.111.0"
-    "@aws-cdk/cx-api" "1.111.0"
+    "@aws-cdk/cloud-assembly-schema" "1.113.0"
+    "@aws-cdk/cx-api" "1.113.0"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     glob "^7.1.7"


### PR DESCRIPTION
* Added code to manifest-lambda stack to create a new public-graphql-lambda which will allow the unauthenticated caller to query one of these AppSync resolvers:  ['listPublicPortfolioCollections', 'listHighlightedPortfolioCollections', 'listPublicFeaturedPortfolioCollections', 'getExposedPortfolioCollection']. This will be used by the website to serve public portfolio content without exposing the GraphQL API Keys.
* Created a new API Gateway in front on this new lambda
* Added code to manifest-lambda deployment pipeline to pass an appropriate name for the new API Gateway
* Removed obsolete marble manifest CDN and associated SPA redirection lambda from marble-pipeline-stack
* Added smoke tests for new API Gateway