### PR TITLE
Fix SLO alarm email

### DIFF
--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -149,7 +149,7 @@
 
   "multimediaAssets:cacheTtl": 86400,
 
-  "slos:emailSubscriber": "rfox2@nd.edu",
+  "slos:emailSubscriber": "hesburgh-libraries-duty-office-list@nd.edu",
   "slos:sloDocLink": "https://docs.google.com/document/d/1AZGtz4es6fPMPzgkJuDOL0RDULFpy97emeKMPFYxyCA/edit",
   "slos:runbookLink": "https://github.com/ndlib/TechnologistsPlaybook/tree/master/run-books",
   "slos:debugDashboardLink": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Marble",


### PR DESCRIPTION
Now that we're out of beta, need to send alarms to the Duty Officer list.