### PR TITLE
Fix bucket logging

### DIFF
--- a/deploy/cdk/lib/static-host/static-host-stack.ts
+++ b/deploy/cdk/lib/static-host/static-host-stack.ts
@@ -70,7 +70,7 @@ export class StaticHostStack extends cdk.Stack {
 
     this.bucket = new s3.Bucket(this, 'SiteBucket', {
       serverAccessLogsBucket: props.foundationStack.logBucket,
-      serverAccessLogsPrefix: `s3/${this.hostname}`,
+      serverAccessLogsPrefix: `s3/${this.hostname}/`,
     })
 
     let websiteCertificate: ICertificate


### PR DESCRIPTION
The bucket logs for static sites aren't being properly prefixed, causing
Athena queries to have to scan all static-site logs (very slow) when
looking for a single site. Added a / at the end to properly partition
by site name.