### PR TITLE
update the resolvers to take into account if the api key or open id connect token is sent to the profile resolvers

### DIFF
--- a/deploy/cdk/lib/maintain-metadata/schema.graphql
+++ b/deploy/cdk/lib/maintain-metadata/schema.graphql
@@ -276,7 +276,7 @@ type PortfolioCollection @aws_oidc @aws_api_key {
 	portfolioItems: PortfolioItemsConnection
 	title: String
 	creator: PortfolioUser
-}	
+}
 
 type PortfolioCollectionsConnection @aws_oidc @aws_api_key {
 	items: [PortfolioCollection]
@@ -298,7 +298,7 @@ type PortfolioItem @aws_oidc @aws_api_key {
 	sequence: Int
 	title: String
 	uri: String
-}	
+}
 
 type PortfolioItemsConnection @aws_oidc @aws_api_key {
 	items: [PortfolioItem]
@@ -328,7 +328,7 @@ type PortfolioUser @aws_oidc @aws_api_key {
 	email: String
 	primaryAffiliation: String
 	portfolioCollections: PortfolioCollectionsConnection
-}	
+}
 
 type Query @aws_oidc @aws_api_key {
 	getExposedPortfolioCollection(portfolioCollectionId: String!): PortfolioCollection
@@ -338,9 +338,9 @@ type Query @aws_oidc @aws_api_key {
 	getItem(id: String!, websiteId: String): ItemMetadata
 	getMedia(id: String!): Media
 	getMediaGroup(id: String!): MediaGroup
-	getPortfolioCollection(portfolioCollectionId: String!): PortfolioCollection  @aws_oidc
-	getPortfolioItem(portfolioCollectionId: String!, portfolioItemId: String!): PortfolioItem  @aws_oidc
-	getPortfolioUser: PortfolioUser  @aws_oidc
+	getPortfolioCollection(portfolioCollectionId: String!): PortfolioCollection  @aws_oidc @aws_api_key
+	getPortfolioItem(portfolioCollectionId: String!, portfolioItemId: String!): PortfolioItem  @aws_oidc 
+	getPortfolioUser: PortfolioUser  @aws_oidc @aws_api_key
 	getWebsite(id: String!): Website
 	listFilesToProcess(dateLastProcessedBefore: String, limit: Int, nextToken: String): FilesToProcessConnection
 	listImageGroups(limit: Int, nextToken: String, storageSystem: StorageSystem): ImageGroupsConnection


### PR DESCRIPTION
allow getUserPortfolio to return data if there is an API key
update the .collections to return public API if the user in the login API does not equal the source.portfolioUserId
update the getPortfolioCollection so that it checks if the API user in the token is the current owner of the record. 