### PR TITLE
Fix python version checking

### DIFF
--- a/deploy/cdk/lib/manifest-lambda/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-lambda/deployment-pipeline.ts
@@ -55,7 +55,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'chmod -R 755 ./scripts/codebuild/*',
           `export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_${infraSourceArtifact.artifactName}"`,
           './scripts/codebuild/install.sh',
-          'pyenv versions',
+          'pyenv version || { echo "Python version mismatch"; exit 1; }',
           'yarn',
         ],
         outputFiles: [
@@ -143,7 +143,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
               python: '3.8',
             },
             commands: [
-              'pyenv versions',
+              'pyenv version || { echo "Python version mismatch"; exit 1; }',
               'pip install -r dev-requirements.txt',
               'chmod -R 755 ./scripts/codebuild/*',
               './scripts/codebuild/install.sh',

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -59,7 +59,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'chmod -R 755 ./scripts/codebuild/*',
           `export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_${infraSourceArtifact.artifactName}"`,
           './scripts/codebuild/install.sh',
-          'pyenv versions',
+          'pyenv version || { echo "Python version mismatch"; exit 1; }',
           'yarn',
         ],
         outputFiles: [
@@ -223,7 +223,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
               python: '3.8',
             },
             commands: [
-              'pyenv versions',
+              'pyenv version || { echo "Python version mismatch"; exit 1; }',
               'pip install -r dev-requirements.txt',
               'chmod -R 755 ./scripts/codebuild/*',
               './scripts/codebuild/install.sh',


### PR DESCRIPTION
`pyenv versions` will list the versions available, but crucially will not stop the execution flow if there is an error. This change uses `pyenv version` which will check the .python-version file and make sure it matches with the environment of the codebuild. If there is a mismatch, exit out and cause the codebuild to fail so we don't get sneaky errors in production. 😅 