### PR TITLE
Fix misnamed context value

### DIFF
--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -140,7 +140,7 @@
   "maintainMetadata:openIdConnectProvider": "https://okta.nd.edu/oauth2/ausxosq06SDdaFNMB356",
 
   "manifestLambda:hostnamePrefix": "iiif-manifest",
-  "manfiestLambda:sentryDsn": "https://136d489c91484b55be18e0a28d463b43@sentry.io/1831199",
+  "manifestLambda:sentryDsn": "https://136d489c91484b55be18e0a28d463b43@sentry.io/1831199",
   "manifestLambda:lambdaCodeRootPath": "../../../marble-manifest-lambda",
   "manifestLambda:appRepoOwner": "ndlib",
   "manifestLambda:appRepoName": "marble-manifest-lambda",


### PR DESCRIPTION
I don't know if we actually have Sentry logging enabled for this... But if we do, it would help to actually pass the value to the stack. 😄 