### PR TITLE
Remove dependence on newman image and normalize approvals

### DIFF
--- a/deploy/cdk/lib/github-approval.ts
+++ b/deploy/cdk/lib/github-approval.ts
@@ -1,0 +1,55 @@
+import { GitHubSourceAction, ManualApprovalAction, ManualApprovalActionProps } from "@aws-cdk/aws-codepipeline-actions"
+
+export interface GithubSourceProps {
+  /**
+   * Repo owner. Because we can't get this from the source action
+   */
+  readonly owner: string
+
+  /**
+   * A GitHubSourceAction that is used when deploying a change
+   */
+  readonly sourceAction: GitHubSourceAction
+}
+
+export interface GithubApprovalProps extends Omit<ManualApprovalActionProps, 'actionName'> {
+  /**
+   * List of Github sources from which to add commit details for the approval message
+   */
+  readonly githubSources: GithubSourceProps[]
+
+  /**
+   * Where to direct a reviewer to see the changes before they're pushed to production
+   */
+  readonly testTarget: string
+
+  /**
+   * The target that will be changed if the reviewer approves the change
+   */
+  readonly prodTarget: string
+
+  /**
+   * Alternate name to use for the action in the pipeline stage. Default: "Approval"
+   */
+  readonly actionName?: string
+}
+
+export class GithubApproval extends ManualApprovalAction {
+    /**
+     * Constructs an approval that contains links to the target hosts, the repos that were sourced, and a summary of the changes that are being pushed
+     * @param props
+     */
+    constructor(props: GithubApprovalProps){
+      const header = `Deployment to ${props.testTarget} successful. If approved, will attempt to deploy to ${props.prodTarget}.\n\n*Sources*\n`
+      const changeInfo = props.githubSources.reduce((prev, current) =>
+        `${prev}<https://github.com/${current.owner}/${current.sourceAction.variables.repositoryName}/commit/${current.sourceAction.variables.commitId}|*\`${current.sourceAction.variables.repositoryName}\`* changed on ${current.sourceAction.variables.authorDate}> - ${current.sourceAction.variables.commitMessage}\n\n`,
+        header,
+      )
+      const defaults: ManualApprovalActionProps = {
+        actionName: props.actionName ?? 'Approval',
+        additionalInformation: props.additionalInformation ?? changeInfo,
+        runOrder: props.runOrder ?? 99, // This should always be the last action in the stage
+      }
+      super({ ...defaults, ...props })
+    }
+}

--- a/deploy/cdk/lib/image-processing/deployment-pipeline.ts
+++ b/deploy/cdk/lib/image-processing/deployment-pipeline.ts
@@ -8,6 +8,7 @@ import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { NamespacedPolicy, GlobalActions } from '../namespaced-policy'
 import { FoundationStack, PipelineFoundationStack } from '../foundation'
+import { GithubApproval } from '../github-approval'
 
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
@@ -110,13 +111,15 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const deployTest = createDeploy(testStackName, `${props.namespace}-test`, props.testFoundationStack)
 
     // Approval
-    const appRepoUrl = `https://github.com/${props.appRepoOwner}/${props.appRepoName}`
     const approvalTopic = new Topic(this, 'ApprovalTopic')
-    const approvalAction = new ManualApprovalAction({
-      actionName: 'Approval',
-      additionalInformation: `A new version of ${appRepoUrl} has been deployed to stack '${testStackName}' and is awaiting your approval. If you approve these changes, they will be deployed to stack '${prodStackName}'.`,
+    const approvalAction = new GithubApproval({
       notificationTopic: approvalTopic,
-      runOrder: 99, // This should always be the last action in the stage
+      testTarget: `stack ${testStackName}`,
+      prodTarget: `stack ${prodStackName}`,
+      githubSources: [
+        { owner: props.appRepoOwner, sourceAction: appSourceAction },
+        { owner: props.infraRepoOwner, sourceAction: infraSourceAction },
+      ],
     })
     if(props.slackNotifyStackName !== undefined){
       const slackApproval = new SlackApproval(this, 'SlackApproval', {

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -9,6 +9,7 @@ import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk'
 import { CDKPipelineDeploy } from '../cdk-pipeline-deploy'
 import { NamespacedPolicy } from '../namespaced-policy'
 import { PipelineFoundationStack } from '../foundation'
+import { GithubApproval } from '../github-approval'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly pipelineFoundationStack: PipelineFoundationStack
@@ -251,13 +252,15 @@ export class DeploymentPipelineStack extends cdk.Stack {
     const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, props.imageServiceStackName, props.dataProcessingKeyPath, `${props.namespace}-manifest-deploy-test`, false, props.metadataTimeToLiveDays, props.filesTimeToLiveDays, false)
 
     // Approval
-    const appRepoUrl = `https://github.com/${props.appRepoOwner}/${props.appRepoName}`
     const approvalTopic = new Topic(this, 'ApprovalTopic')
-    const approvalAction = new ManualApprovalAction({
-      actionName: 'Approval',
-      additionalInformation: `A new version of ${appRepoUrl} has been deployed to stack '${testStackName}' and is awaiting your approval. If you approve these changes, they will be deployed to stack '${prodStackName}'.`,
+    const approvalAction = new GithubApproval({
       notificationTopic: approvalTopic,
-      runOrder: 99, // This should always be the last action in the stage
+      testTarget: `stack ${testStackName}`,
+      prodTarget: `stack ${prodStackName}`,
+      githubSources: [
+        { owner: props.appRepoOwner, sourceAction: appSourceAction },
+        { owner: props.infraRepoOwner, sourceAction: infraSourceAction },
+      ],
     })
     if(props.slackNotifyStackName !== undefined){
       new SlackApproval(this, 'SlackApproval', {

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -15,6 +15,7 @@ import { ElasticStack } from '../elasticsearch'
 import { DockerhubImage } from '../dockerhub-image'
 import { MaintainMetadataStack } from '../maintain-metadata'
 import { ManifestLambdaStack } from '../manifest-lambda'
+import { GithubApproval } from '../github-approval'
 
 export interface IDeploymentPipelineStackProps extends cdk.StackProps {
   readonly pipelineFoundationStack: PipelineFoundationStack
@@ -214,22 +215,6 @@ export class DeploymentPipelineStack extends cdk.Stack {
       actionName: 'SmokeTests',
     })
 
-    // Approval
-    const appRepoUrl = `https://github.com/${props.appRepoOwner}/${props.appRepoName}`
-    const approvalTopic = new Topic(this, 'ApprovalTopic')
-    const approvalAction = new ManualApprovalAction({
-      actionName: 'Approval',
-      additionalInformation: `A new version of ${appRepoUrl} has been deployed to stack '${testStackName}' and is awaiting your approval. If you approve these changes, they will be deployed to stack '${prodStackName}'.`,
-      notificationTopic: approvalTopic,
-      runOrder: 99, // This should always be the last action in the stage
-    })
-    if (props.slackNotifyStackName !== undefined) {
-      new SlackApproval(this, 'SlackApproval', {
-        approvalTopic,
-        notifyStackName: props.slackNotifyStackName,
-      })
-    }
-
     // Deploy to Production
     const prodHostnamePrefix = props.hostnamePrefix ? props.hostnamePrefix : `${props.namespace}-${props.instanceName}`
     const prodBuildPath = `$CODEBUILD_SRC_DIR_${appSourceArtifact.artifactName}`
@@ -267,6 +252,24 @@ export class DeploymentPipelineStack extends cdk.Stack {
       },
       actionName: 'SmokeTests',
     })
+
+    // Approval
+    const approvalTopic = new Topic(this, 'ApprovalTopic')
+    const approvalAction = new GithubApproval({
+      notificationTopic: approvalTopic,
+      testTarget: `https://${testHostname}`,
+      prodTarget: `https://${prodHostname}`,
+      githubSources: [
+        { owner: props.appRepoOwner, sourceAction: appSourceAction },
+        { owner: props.infraRepoOwner, sourceAction: infraSourceAction },
+      ],
+    })
+    if (props.slackNotifyStackName !== undefined) {
+      new SlackApproval(this, 'SlackApproval', {
+        approvalTopic,
+        notifyStackName: props.slackNotifyStackName,
+      })
+    }
 
     // Pipeline
     const sources = [appSourceAction, infraSourceAction]


### PR DESCRIPTION
**Move to using the ndlib-cdk provided newman runner**

This is to avoid using a custom image for our CodeBuilds. Newman in
particular is a relatively fast package to install at runtime, so it
shouldn't add a significant time to the execution of the pipelines.

**Normalize the approval messages**

Added a reusable construct for creating approval actions for pipelines
that are based on Github sources. Changed all pipelines to use this
construct instead of forming their own messages. The message could probably
use a little more iteration to make it more concise, but should be easier
to do so now that it's in one place. Here's an example of what it will
look like: [User content approval message](https://app.slack.com/block-kit-builder/T8C2X85T2#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22*Pipeline*%5Cn%3Chttps://console.aws.amazon.com/codesuite/codepipeline/pipelines/marbleb-user-content-deployment-DeploymentPipelineEDAF206A-BUKXJ1OH1UQI/view?region=us-east-1%7Cmarbleb-user-content-deployment-DeploymentPipelineEDAF206A-BUKXJ1OH1UQI%3E%5Cn%5Cn*Message*%5CnDeployment%20to%20https://marble-user-content-test.library.nd.edu%20successful.%20If%20approved,%20will%20attempt%20to%20deploy%20to%20https://marble-user-content.library.nd.edu.%5Cn%5Cn*Sources*%5Cn%3Chttps://github.com/ndlib/marble-user-content/commit/47f26a402701d1b5c9d387ed949730b012aeda7a%7C*%60marble-user-content%60*%20changed%20on%202021-09-01T20:11:08Z%3E%20-%20Merge%20pull%20request%20#17%20from%20ndlib/flatten-smoke-tests%5Cn%5CnMove%20smoke%20tests%20to%20separate%20collection%5Cn%5Cn%3Chttps://github.com/ndlib/marble-blueprints/commit/79e1c09e5690c15cc3b017e29aa8b2bea1f0ef8b%7C*%60marble-blueprints%60*%20changed%20on%202021-08-31T15:05:24Z%3E%20-%20Merge%20pull%20request%20#314%20from%20ndlib/fix-python-mismatch-not-exiting%5Cn%5CnFix%20python%20version%20checking%5Cn%5Cn%22%7D%7D%5D%7D)