### PR TITLE
Silence IIIF Image Service API Latency P95 >= 3000ms (Low Severity)

### DIFF
--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -172,6 +172,10 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
       apiName: iiifServerlessStack.apiStack.apiName,
       sloThreshold: 0.95,
       latencyThreshold: 3000,
+      alarmsEnabled: {
+        High: true,
+        Low: false,
+      },
     },
     {
       title: "Marble - IIIF Manifest API",


### PR DESCRIPTION
A ticket has been created to see what can be done about this alarm:
https://jira.library.nd.edu/browse/MARBLE-1929. Silencing for now until
this investigation is done.