### PR TITLE
Forward synthetics-timestamp param to origin

### DIFF
--- a/deploy/cdk/lib/static-host/static-host-stack.ts
+++ b/deploy/cdk/lib/static-host/static-host-stack.ts
@@ -122,6 +122,15 @@ export class StaticHostStack extends cdk.Stack {
                   lambdaFunction: this.spaRedirectionLambda.currentVersion,
                 },
               ],
+              forwardedValues: {
+                cookies: {
+                  forward: 'none',
+                },
+                queryString: true,
+                queryStringCacheKeys: [
+                  'synthetics-timestamp',
+                ],
+              },
             },
           ],
         },


### PR DESCRIPTION
This adds the `synthetics-timestamp` query parameter to the list of
forwarded values to the s3 origin. This is so that our synthetics can
force a cache miss on every request to better monitor availability and
latencies for origin requests.

Note: The additional `cookies: { forward: none }` is to preserve the
previous behavior after adding our own `forwardedValues`