### PR TITLE
Change static host to support additional aliases

### DIFF
--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -11,14 +11,24 @@ import manifestPipeline = require('../lib/manifest-pipeline')
 import maintainMetadata = require('../lib/maintain-metadata')
 import multimediaAssets = require('../lib/multimedia-assets')
 import manifestLambda = require('../lib/manifest-lambda')
-import { getContextByNamespace } from '../lib/context-helpers'
+import { getContextByNamespace, mapContextToProps, TypeHint } from '../lib/context-helpers'
 import { ContextEnv } from '../lib/context-env'
 import { Stacks } from '../lib/types'
 import { ServiceLevelsStack } from '../lib/service-levels/service-levels-stack'
+import { IStaticHostStackProps } from '../lib/static-host'
+import { Bucket } from '@aws-cdk/aws-s3'
 
 export const instantiateStacks = (app: App, namespace: string, contextEnv: ContextEnv): Stacks => {
+  const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
+    useVpcId: contextEnv.useVpcId,
+    useExistingDnsZone: contextEnv.useExistingDnsZone,
+    env: contextEnv.env,
+    domainName: contextEnv.domainName,
+  })
+
   // Construct common props that are required by all service stacks
   const commonProps = {
+    foundationStack,
     namespace,
     env: contextEnv.env,
     contextEnvName: contextEnv.name,
@@ -26,109 +36,59 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     domainName: contextEnv.domainName,
   }
 
-  const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
-    useVpcId: contextEnv.useVpcId,
-    useExistingDnsZone: contextEnv.useExistingDnsZone,
-    ...commonProps,
-  })
+  const staticHostTypeHints : TypeHint = { additionalAliases: 'csv' }
+  const websiteProps = mapContextToProps<IStaticHostStackProps>('website', commonProps, staticHostTypeHints)
+  const website = new staticHost.StaticHostStack(app, `${namespace}-website`, websiteProps)
 
-  const websiteContext = getContextByNamespace('website')
-  const website = new staticHost.StaticHostStack(app, `${namespace}-website`, {
-    foundationStack,
-    ...commonProps,
-    ...websiteContext,
-  })
+  const redboxProps = mapContextToProps<IStaticHostStackProps>('redbox', commonProps, staticHostTypeHints)
+  const redbox = new staticHost.StaticHostStack(app, `${namespace}-redbox`, redboxProps)
 
-  const redboxContext = getContextByNamespace('redbox')
-  const redbox = new staticHost.StaticHostStack(app, `${namespace}-redbox`, {
-    foundationStack,
-    ...commonProps,
-    ...redboxContext,
-  })
+  const inquisitionsProps = mapContextToProps<IStaticHostStackProps>('inquisitions', commonProps, staticHostTypeHints)
+  const inquisitions = new staticHost.StaticHostStack(app, `${namespace}-inquisitions`, inquisitionsProps)
 
-  const inquisitionsContext = getContextByNamespace('inquisitions')
-  const inquisitions = new staticHost.StaticHostStack(app, `${namespace}-inquisitions`, {
-    foundationStack,
-    ...commonProps,
-    ...inquisitionsContext,
-  })
+  const viewerProps: IStaticHostStackProps = mapContextToProps<IStaticHostStackProps>('viewer', commonProps, staticHostTypeHints)
+  const viewer = new staticHost.StaticHostStack(app, `${namespace}-viewer`, viewerProps)
 
-  const viewerContext = getContextByNamespace('viewer')
-  const viewer = new staticHost.StaticHostStack(app, `${namespace}-viewer`, {
-    foundationStack,
-    ...commonProps,
-    ...viewerContext,
-  })
+  const imageServiceProps = mapContextToProps<IIIF.IIiifServerlessStackProps>('iiifImageService', commonProps)
+  const iiifServerlessStack = new IIIF.IiifServerlessStack(app, `${namespace}-image-service`, imageServiceProps)
 
-  const imageServiceContext = getContextByNamespace('iiifImageService')
-  const iiifServerlessStack = new IIIF.IiifServerlessStack(app, `${namespace}-image-service`, {
-    foundationStack,
-    ...commonProps,
-    ...imageServiceContext,
-  })
+  const userContentProps = mapContextToProps<userContent.UserContentStackProps>('userContent', commonProps)
+  const userContentStack = new userContent.UserContentStack(app, `${namespace}-user-content`, userContentProps)
 
-  const userContentContext = getContextByNamespace('userContent')
-  const userContentStack = new userContent.UserContentStack(app, `${namespace}-user-content`, {
-    foundationStack,
-    ...commonProps,
-    ...userContentContext,
-  })
+  const elasticsearchProps = mapContextToProps<elasticsearch.ElasticStackProps>('elasticsearch', commonProps)
+  const elasticSearchStack = new elasticsearch.ElasticStack(app, `${namespace}-elastic`, elasticsearchProps)
 
-  const elasticsearchContext = getContextByNamespace('elasticsearch')
-  const elasticSearchStack = new elasticsearch.ElasticStack(app, `${namespace}-elastic`, {
-    foundationStack,
+  const multimediaAssetsProps = mapContextToProps<multimediaAssets.IMultimediaAssetsStackProps>('multimediaAssets', {
     ...commonProps,
-    ...elasticsearchContext,
-  })
-
-  const multimediaAssetsContext = getContextByNamespace('multimediaAssets')
-  const multimediaAssetsStack = new multimediaAssets.MultimediaAssetsStack(app, `${namespace}-multimedia-assets`, {
-    foundationStack,
     marbleContentBucketName: contextEnv.marbleContentBucketName,
-    ...commonProps,
-    ...multimediaAssetsContext,
   })
+  const multimediaAssetsStack = new multimediaAssets.MultimediaAssetsStack(app, `${namespace}-multimedia-assets`, multimediaAssetsProps)
 
-  const manifestPipelineContext = getContextByNamespace('manifestPipeline')
-  const manifestPipelineStack = new manifestPipeline.ManifestPipelineStack(app, `${namespace}-manifest`, {
-    foundationStack,
+  const manifestPipelineProps = mapContextToProps<manifestPipeline.IBaseStackProps>('manifestPipeline', {
+    ...commonProps,
     sentryDsn: app.node.tryGetContext('sentryDsn'),
-    createEventRules: app.node.tryGetContext('manifestPipeline:createEventRules') === "true" ? true : false,
-    appConfigPath: app.node.tryGetContext('manifestPipeline:appConfigPath') ? app.node.tryGetContext('manifestPipeline:appConfigPath') : `/all/stacks/${namespace}-manifest`,
+    appConfigPath: `/all/stacks/${namespace}-manifest`,
     rBSCS3ImageBucketName: contextEnv.rBSCS3ImageBucketName,
     marbleContentBucketName: contextEnv.marbleContentBucketName,
-    multimediaBucket: multimediaAssetsStack.multimediaBucket,
+    multimediaBucket: multimediaAssetsStack.multimediaBucket as Bucket,
     marbleContentFileShareId: contextEnv.marbleContentFileShareId,
-    ...commonProps,
-    ...manifestPipelineContext,
-  })
+  }, { createEventRules: 'boolean' })
+  const manifestPipelineStack = new manifestPipeline.ManifestPipelineStack(app, `${namespace}-manifest`, manifestPipelineProps)
 
-  const maintainMetadataContext = getContextByNamespace('maintainMetadata')
-  const maintainMetadataStack = new maintainMetadata.MaintainMetadataStack(app, `${namespace}-maintain-metadata`, {
-    foundationStack,
-    manifestPipelineStack,
-    ...commonProps,
-    ...maintainMetadataContext,
-  })
+  const maintainMetadataProps = mapContextToProps<maintainMetadata.IBaseStackProps>('maintainMetadata', { ...commonProps, manifestPipelineStack })
+  const maintainMetadataStack = new maintainMetadata.MaintainMetadataStack(app, `${namespace}-maintain-metadata`, maintainMetadataProps)
 
-  const imageProcessingContext = getContextByNamespace('imageProcessing')
-  const imageProcessingStack = new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, {
-    foundationStack,
+  const imageProcessingProps = mapContextToProps<imageProcessing.ImagesStackProps>('imageProcessing', {
+    ...commonProps,
     rbscBucketName: contextEnv.rBSCS3ImageBucketName,
     marbleContentBucketName: contextEnv.marbleContentBucketName,
     manifestPipelineStack,
     maintainMetadataStack,
-    ...commonProps,
-    ...imageProcessingContext,
   })
+  const imageProcessingStack = new imageProcessing.ImagesStack(app, `${namespace}-image-processing`, imageProcessingProps)
 
-  const manifestLambdaContext = getContextByNamespace('manifestLambda')
-  const manifestLambdaStack = new manifestLambda.ManifestLambdaStack(app, `${namespace}-manifest-lambda`, {
-    foundationStack,
-    maintainMetadataStack,
-    ...commonProps,
-    ...manifestLambdaContext,
-  })
+  const manifestLambdaProps = mapContextToProps<manifestLambda.IBaseStackProps>('manifestLambda', { ...commonProps, maintainMetadataStack })
+  const manifestLambdaStack = new manifestLambda.ManifestLambdaStack(app, `${namespace}-manifest-lambda`, manifestLambdaProps)
 
   const services = {
     foundationStack,

--- a/deploy/cdk/lib/context-helpers.ts
+++ b/deploy/cdk/lib/context-helpers.ts
@@ -23,3 +23,42 @@ export const getRequiredContext = (node: ConstructNode, key: string) => {
   }
   return value
 }
+
+export type TypeHint = { [key: string]: 'csv' | 'boolean' }
+
+/**
+ * Maps context key value pairs within a namespace to typed props. If a set of defaults are given
+ * it will initially populate the props with these defaults, and overwrite the defaults with values
+ * from context. If provided type hints, it will use these to determine how to deserialize the value.
+ * Ex: to deserialize comma separated values to Array<string>, boolean strings to boolean, etc. If not
+ * specified, the default conversion of `any` to the prop type will occur.
+ */
+export const mapContextToProps = <T> (ns: string, defaults?: Partial<T>, typeHints?: TypeHint): T => {
+  const types = typeHints ?? {}
+  type keyTypes = keyof T
+  const result: any = defaults ?? {}
+  const prefix = `${ns}:`
+  for (const [key, value] of Object.entries(allContext)) {
+    if(key.startsWith(prefix)){
+      const flattenedKey = key.substr(prefix.length)
+      const k: keyTypes = <keyTypes>flattenedKey
+      const v = value as T[keyTypes]
+      const typeHint = types[flattenedKey]
+      switch(typeHint){
+        case 'csv':
+          {
+            const valueArray = (<string>value).split(',')
+            result[k] = valueArray.map(v => v.trim())
+          }
+          break
+        case 'boolean':
+          result[k] = (<string>value).toLowerCase() == 'true' ? true : false
+          break
+        default:
+          result[k] = value
+          break
+      }
+    }
+  }
+  return result as T
+}

--- a/deploy/cdk/lib/static-host/static-host-stack.ts
+++ b/deploy/cdk/lib/static-host/static-host-stack.ts
@@ -32,6 +32,11 @@ export interface IStaticHostStackProps extends cdk.StackProps {
    * Optional domainName override
    */
   readonly domainNameOverride?: string
+
+  /**
+   * Optional additional aliases
+   */
+  readonly additionalAliases?: Array<string>
 }
 
 export class StaticHostStack extends cdk.Stack {
@@ -67,7 +72,10 @@ export class StaticHostStack extends cdk.Stack {
 
     const domainName = props.domainNameOverride || props.foundationStack.hostedZone.zoneName
     this.hostname = `${props.hostnamePrefix || this.stackName}.${domainName}`
-
+    const aliases = [
+      this.hostname,
+      ...(props.additionalAliases ?? []),
+    ]
     this.bucket = new s3.Bucket(this, 'SiteBucket', {
       serverAccessLogsBucket: props.foundationStack.logBucket,
       serverAccessLogsPrefix: `s3/${this.hostname}/`,
@@ -136,7 +144,7 @@ export class StaticHostStack extends cdk.Stack {
         },
       ],
       viewerCertificate: ViewerCertificate.fromAcmCertificate(websiteCertificate, {
-        aliases: [this.hostname],
+        aliases,
         securityPolicy: SecurityPolicyProtocol.TLS_V1_1_2016,
         sslMethod: SSLMethod.SNI,
       }),


### PR DESCRIPTION
This is primarily to change the static host stack to support provisioning
additional aliases on the cloudfront so that both `marble.nd.edu` and
`marble.library.nd.edu` work.

To get this to work, I needed the ability to pass context overrides with
a list of values (csv), ex: `-c "additionalAliases=abc.nd.edu, xyz.nd.edu"`.
I've added a new mapContextToProps to better handle the deserialization
of prop types from context. I could not figure out a great way to
determine the type of the prop that the value is being applied to (since
these are interfaces), so the caller will just have to specify this with
type hints on each call.

As an example, this call:
`mapContextToProps<IStaticHostStackProps>('website', defaults, { additionalAliases: 'csv' })`
will:
1. Initialize a IStaticHostStackProps object with the passed defaults
2. Glob all context keys with a `website:` prefix
3. Override the given defaults with the globbed values, parsing any
additionalAliases from csv to an array.

Type hints can also be used to convert boolean strings from context to
booleans.

This change also improves the type checking on any values passed as
defaults before context overrides are applied. Given that context is
something still read in at runtime, I could not improve the type checking
on it, but this at least improves the type checking on any values passed
as defaults.

With that added, the rest of the changes are related to getting the website
pipeline to add a `-c "additionalAliases=marble.library.nd.edu"` specifically
for the prod stack only.