### PR TITLE
Add detailed dashboards

### DIFF
--- a/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
+++ b/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
@@ -132,6 +132,7 @@ export class ManifestLambdaStack extends Stack {
         domainName: iiifApiBaseUrl,
       },
       endpointExportName: `${this.stackName}-api-url`,
+      deployOptions: { metricsEnabled: true },
     })
     const iiifManifestIntegration = new apigateway.LambdaIntegration(iiifManifestLambda)
 
@@ -203,6 +204,7 @@ export class ManifestLambdaStack extends Stack {
         domainName: graphqlApiBaseUrl,
       },
       endpointExportName: `${this.stackName}-graphql-api-url`,
+      deployOptions: { metricsEnabled: true },
     })
     const publicGraphqlIntegration = new apigateway.LambdaIntegration(publicGraphqlLambda)
 

--- a/deploy/cdk/lib/monitoring/dashboards-stack.ts
+++ b/deploy/cdk/lib/monitoring/dashboards-stack.ts
@@ -23,6 +23,7 @@ export class DashboardsStack extends Stack {
       [`${props.services.elasticSearchStack.domain.node.addr}`]: 'Search API',
       [`${props.services.manifestLambdaStack.privateApi.node.addr}`]: 'IIIF Manifest API',
       [`${props.services.manifestLambdaStack.publicApi.node.addr}`]: 'User Portfolio API',
+      [`${props.services.multimediaAssetsStack.cloudfront.node.addr}`]: 'Multimedia Assets CDN',
     }
     SummaryDashboard.fromTree(this, "SummaryDashboard", {
       dashboardName: "Marble-Summary",

--- a/deploy/cdk/lib/monitoring/dashboards-stack.ts
+++ b/deploy/cdk/lib/monitoring/dashboards-stack.ts
@@ -1,5 +1,5 @@
 import { App, IConstruct, Stack, StackProps } from '@aws-cdk/core'
-import { SummaryDashboard } from '@ndlib/ndlib-cdk'
+import { CloudfrontDashboard, ServerlessApiDashboard, SummaryDashboard } from '@ndlib/ndlib-cdk'
 import { ServiceStacks } from '../../lib/types'
 
 export interface DashboardsStackProps extends StackProps {
@@ -45,5 +45,77 @@ export class DashboardsStack extends Stack {
         },
       ],
     })
+
+    // We don't yet have an automated way to create more detailed dashboards for each service, 
+    // so we'll make each one individually here
+    new CloudfrontDashboard(this, 'UnifiedWebsiteDashboard', {
+      dashboardName: 'Marble-Unified-Website-CDN',
+      headerName: 'Unified Website CDN',
+      desc: 'Placeholder',
+      distributionId: props.services.website.cloudfront.distributionId,
+    })
+
+    new CloudfrontDashboard(this, 'RedboxDashboard', {
+      dashboardName: 'Marble-Redbox-CDN',
+      headerName: 'Redbox CDN',
+      desc: 'Placeholder',
+      distributionId: props.services.redbox.cloudfront.distributionId,
+    })
+
+    new CloudfrontDashboard(this, 'InquisitionsDashboard', {
+      dashboardName: 'Marble-Inquisitions-CDN',
+      headerName: 'Inquisitions CDN',
+      desc: 'Placeholder',
+      distributionId: props.services.inquisitions.cloudfront.distributionId,
+    })
+
+    new CloudfrontDashboard(this, 'IIIFViewerDashboard', {
+      dashboardName: 'Marble-IIIF-Viewer-CDN',
+      headerName: 'IIIF Viewer CDN',
+      desc: 'Placeholder',
+      distributionId: props.services.viewer.cloudfront.distributionId,
+    })
+
+    new CloudfrontDashboard(this, 'MultimediaAssetsDashboard', {
+      dashboardName: 'Marble-Multimedia-Assets-CDN',
+      headerName: 'Multimedia Assets CDN',
+      desc: 'Placeholder',
+      distributionId: props.services.multimediaAssetsStack.cloudfront.distributionId,
+    })
+
+    new ServerlessApiDashboard(this, 'IIIFManifestDashboard', {
+      dashboardName: 'Marble-IIIF-Manifest-API',
+      headerName: 'IIIF Manifest API',
+      desc: 'Placeholder',
+      apiName: props.services.manifestLambdaStack.privateApi.restApiName,
+      stage: props.services.manifestLambdaStack.privateApi.deploymentStage.stageName,
+      latencyPercentiles: [{ thresholdLabel: 'SLO', threshold: 3000, percentile: 0.95 }],
+    })
+
+    new ServerlessApiDashboard(this, 'UserPortfolioDashboard', {
+      dashboardName: 'Marble-User-Portfolio-API',
+      headerName: 'User Portfolio API',
+      desc: 'Placeholder',
+      apiName: props.services.manifestLambdaStack.publicApi.restApiName,
+      stage: props.services.manifestLambdaStack.privateApi.deploymentStage.stageName,
+    })
+
+    // These don't exist yet in ndlib-cdk, so just projecting what they might look like
+    // TODO: new GraphqlApiDashboard(this, 'MaintainMetadataAPI', {
+    //   dashboardName: 'Marble-Maintain-Metadata-API',
+    //   headerName: 'Maintain Metadata API',
+    //   desc: 'Placeholder',
+    //   apiId: props.services.maintainMetadataStack.api.apiId,
+    //   ...
+    // })
+
+    // TODO: new ElasticSearchApiDashboard(this, 'SearchAPI', {
+    //   dashboardName: 'Marble-Search-API',
+    //   headerName: 'Search API',
+    //   desc: 'Placeholder',
+    //   accountId: props.services.elasticSearchStack.account,
+    //   domainName: props.services.elasticSearchStack.domain.domainName,
+    //   ...
+    // })
   }
 }


### PR DESCRIPTION
This adds detailed dashboards for all serverless APIs and CloudFront
based CDNs. This additionally changes the manifest lambda apis to enable
detailed metrics. Without this, we won't get metrics per method in the
dashboards.

This does not yet add dashboards for the ElasticSearch and Graphql APIs,
since those do not exist in ndlib-cdk just yet. I've created placeholder
code for now to give an example of what that might look like once it's
added.

Also, added one missed label override for the multimedia assets cloudfront
in the summary dashboard.