### PR TITLE
Downgrade Marble ElasticSearch back to original settings

### DIFF
--- a/deploy/cdk/lib/elasticsearch/elastic-stack.ts
+++ b/deploy/cdk/lib/elasticsearch/elastic-stack.ts
@@ -14,11 +14,11 @@ export class ElasticStack extends cdk.Stack {
 
   constructor(scope: cdk.Construct, id: string, props: ElasticStackProps) {
     super(scope, id, props)
-    this.domainName = `${props.namespace}-sites`
+    this.domainName = `${props.namespace}-sites`  // We'd like to let CloudFormation define the domain name, but we can't because of synthetics
     const anonSearch = `arn:aws:es:${Aws.REGION}:${Aws.ACCOUNT_ID}:domain/${this.domainName}/*/_search`
 
     this.domain = new CfnDomain(this, `${props.namespace}-domain`, {
-      elasticsearchVersion: '7.10',
+      elasticsearchVersion: '7.7',
       elasticsearchClusterConfig: this.configCluster(props.contextEnvName),
       ebsOptions: {
         ebsEnabled: true,
@@ -55,8 +55,7 @@ export class ElasticStack extends cdk.Stack {
       instanceType: 't2.small.elasticsearch',
     }
     if (this.isProd(environment)) {
-      config.instanceCount = 3
-      config.instanceType = 't2.medium.elasticsearch'
+      config.instanceCount = 2
       config.zoneAwarenessEnabled = true
       config.zoneAwarenessConfig = { availabilityZoneCount: 2 }
     }

--- a/deploy/cdk/package.json
+++ b/deploy/cdk/package.json
@@ -64,7 +64,7 @@
     "@aws-cdk/custom-resources": "1.132.0",
     "@ndlib/ndlib-cdk": "1.11.0",
     "@types/source-map-support": "^0.5.2",
-    "constructs": "3.3.85",
+    "constructs": "3.3.161",
     "leaked-handles": "^5.2.0",
     "source-map-support": "^0.5.16"
   }

--- a/deploy/cdk/yarn.lock
+++ b/deploy/cdk/yarn.lock
@@ -2308,12 +2308,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-constructs@3.3.85:
-  version "3.3.85"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.85.tgz#9b7496bb6197d04cd061e0509b5b2338355a6469"
-  integrity sha512-Or1CtFHhDLWEO64nFtDGStVSZKu0iOkxJ0y90elLR2zVkkFU7l3VujXRuJxY5Tb1SeuN0hSueC7SnMegFLafcw==
-
-constructs@^3.3.69:
+constructs@3.3.161, constructs@^3.3.69:
   version "3.3.161"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.161.tgz#9726b1d450f3b9aca7907230f2248e3fd4058ce4"
   integrity sha512-/27vW3fo0iyb3py4vKI1BduEYmv8vv8uJgLXvI+5F0Jbnn0/E+As2wkGMa7bumhzCd0Ckv/USkAXstGYVXTYQA==


### PR DESCRIPTION
Made the following changes so the ElasticSearch stack will again deploy:
* Actually downgraded back to ElasticSearch 7.7
* Changed back from 3 nodes to 2 nodes (in production)
* Changed back from 't2.medium.elasticsearch' to 't2.small.elasticsearch'

Ultimately, to change these settings, we need to let CloudFormation define the name of the ElasticSearch domain, but we can't because of synthetics.

Instead, our solution will be to create a separate OpenSearch stack, and deploy that in parallel to ElasticSearch.  Once we update the static host sites to use OpenSearch, we can decommission the ElasticSearch stack.