### PR TITLE
Fix OpenSearch Deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/deploy/cdk/lib/opensearch/deployment-pipeline.ts
+++ b/deploy/cdk/lib/opensearch/deployment-pipeline.ts
@@ -51,7 +51,8 @@ export class DeploymentPipelineStack extends cdk.Stack {
         },
       })
       cdkDeploy.project.addToRolePolicy(NamespacedPolicy.opensearch(namespace))
-      cdkDeploy.project.addToRolePolicy(NamespacedPolicy.opensearchInvoke(namespace))
+      cdkDeploy.project.addToRolePolicy(NamespacedPolicy.opensearch(props.namespace)) // Added to see if this gives me the needed permissions
+      // cdkDeploy.project.addToRolePolicy(NamespacedPolicy.opensearchInvoke(namespace))
       cdkDeploy.project.addToRolePolicy(NamespacedPolicy.ssm(targetStack))
       cdkDeploy.project.addToRolePolicy(
         NamespacedPolicy.globals([GlobalActions.Cloudwatch, GlobalActions.ES, GlobalActions.EC2]))

--- a/deploy/cdk/lib/opensearch/opensearch-stack.ts
+++ b/deploy/cdk/lib/opensearch/opensearch-stack.ts
@@ -20,7 +20,7 @@ export class OpenSearchStack extends cdk.Stack {
     super(scope, id, props)
 
     const masterNodes = 0
-    const dataNodes = this.isProd(props.contextEnvName) ? 3 : 1
+    const dataNodes = this.isProd(props.contextEnvName) ? 4 : 1 // We must choose an even number of data nodes (greater than 2) for a two Availability Zone deployment
     const dataNodeInstanceType = this.isProd(props.contextEnvName) ? 't3.medium.search' : 't3.small.search' // T2 does not support encryption at rest, which is required when selecting useUnsignedBasicAuth
     const zoneAwarenessEanbled = this.isProd(props.contextEnvName) ? true : false
     const zoneAwarenessAvailabilityZoneCount = this.isProd(props.contextEnvName) ? 2 : 2  // 2 is the minimum availability zone count


### PR DESCRIPTION
* Changed opensearch policy based on props.namespace instead of namespace
* Changed the number of opensearch data nodes to 4, since neither 2 nor 3 are valid options.