### PR TITLE
Add image width and height to AppSync

### DIFF
--- a/deploy/cdk/lib/maintain-metadata/schema.graphql
+++ b/deploy/cdk/lib/maintain-metadata/schema.graphql
@@ -17,6 +17,7 @@ type FileToProcess @aws_oidc @aws_api_key {
 	digitalAccess: String
 	eTag: String
 	filePath: String
+	height: Int
 	md5Checksum: String
 	mimeType: String
 	modifiedDate: String
@@ -28,6 +29,7 @@ type FileToProcess @aws_oidc @aws_api_key {
 	sourceUri: String
 	storageSystem: String
 	TYPE: String
+	width: Int
 }
 
 type FilesToProcessConnection @aws_oidc @aws_api_key {
@@ -43,6 +45,7 @@ type Image @aws_oidc @aws_api_key {
 	digitalAccess: String
 	eTag: String
 	filePath: String
+	height: Int
 	lastModified: String
 	mediaResourceId: String
 	mediaServer: String
@@ -58,6 +61,7 @@ type Image @aws_oidc @aws_api_key {
 	treePath: String
 	TYPE: String
 	typeOfData: String
+	width: Int
 }
 
 type ImageGroup @aws_oidc @aws_api_key {
@@ -250,7 +254,7 @@ type Mutation @aws_oidc @aws_api_key {
 	removePortfolioUser: RecordsDeleted @aws_oidc
 	saveCopyrightForWebsite(itemId: String!, websiteId: String, copyrightStatement: String, additionalNotes: String inCopyright: Boolean, copyrightUrl: String, copyrightStatus: String): ItemMetadata
 	saveDefaultImageForWebsite(itemId: String!, websiteId: String, defaultFilePath: String!, imageGroupId: String): ItemMetadata
-	saveFileLastProcessedDate(itemId: String!): FileToProcess
+	saveFileLastProcessedDate(itemId: String!, height: Int, width: Int): FileToProcess
 	saveMediaGroupForWebsite(itemId: String!, websiteId: String, mediaGroupId: String!): ItemMetadata
 	savePartiallyDigitizedForWebsite(itemId: String!, websiteId: String, partiallyDigitized: Boolean!): ItemMetadata
 	savePortfolioCollection(portfolioCollectionId: String, description: String, imageUri: String, layout: String, privacy: PortfolioPrivacy, highlightedCollection: Boolean, featuredCollection: Boolean, title: String): PortfolioCollection @aws_oidc

--- a/deploy/cdk/test/iiif-serverless/iiif-serverless-stack.test.ts
+++ b/deploy/cdk/test/iiif-serverless/iiif-serverless-stack.test.ts
@@ -25,15 +25,12 @@ describe('IiifServerlessStack', () => {
       })
       return parentStack.domainStack
     }
-    console.log("started - before first assert")
     
     test('creates a domain name with the fqdn', () => {
-      console.log("before first test")
       const subject = stack()
       expectCDK(subject).to(haveResourceLike('AWS::ApiGateway::DomainName', {
         DomainName: 'test-iiif.test.com',
       }))
-      console.log("after first test")
     })
 
     test('creates the domain with the cert from the foundation stack', () => {

--- a/deploy/cdk/test/maintain-metadata/stack.test.ts
+++ b/deploy/cdk/test/maintain-metadata/stack.test.ts
@@ -148,6 +148,18 @@ describe('MaintainMetadataStack', () => {
       }))
     })
 
+    test('creates saveFileToProcessRecordFunction', () => {
+      expectCDK(stack).to(haveResourceLike('AWS::AppSync::FunctionConfiguration', {
+        Name: "saveFileToProcessRecordFunction",
+      }))
+    })
+
+    test('creates updateImageRecordFunction', () => {
+      expectCDK(stack).to(haveResourceLike('AWS::AppSync::FunctionConfiguration', {
+        Name: "updateImageRecordFunction",
+      }))
+    })
+
   })
 
 


### PR DESCRIPTION
* Added width and height to FilesToProcess and Image schemas
* Added height and width as parameters for Mutation.saveFileLastProcessedDate
* Created two new functions: saveFileToProcessRecord and updateImageRecord
* Modified the MutationSaveFileLastProcessedDateResolver to be a pipeline instead of a simple resolver, calling updateImageRecordFunction and saveFileToProcessRecordFunction
* Added tests for new functions