### PR TITLE
Add permission to delete AppSync DataSource

### DIFF
--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -82,6 +82,7 @@ export class DeploymentPipelineStack extends cdk.Stack {
           'appsync:GetResolver',
           'appsync:UpdateResolver',
           'appsync:UpdateFunction',
+          'appsync:DeleteDataSource',
         ],
         resources: [
           cdk.Fn.sub('arn:aws:appsync:${AWS::Region}:${AWS::AccountId}:*'),


### PR DESCRIPTION
* This is required to be able to delete a stack (in order to re-deploy)