### PR TITLE
Esu 2081 migrate tests to assertions

### DIFF
--- a/deploy/cdk/package.json
+++ b/deploy/cdk/package.json
@@ -13,7 +13,6 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.141.0",
     "@aws-cdk/cx-api": "1.141.0",
     "@types/jest": "^27.0.3",
     "@typescript-eslint/eslint-plugin": "^5.10.1",

--- a/deploy/cdk/test/maintain-metadata/stack.test.ts
+++ b/deploy/cdk/test/maintain-metadata/stack.test.ts
@@ -1,4 +1,4 @@
-import { expect as expectCDK, haveResource, haveResourceLike } from '@aws-cdk/assert'
+import { Template } from '@aws-cdk/assertions'
 import cdk = require('@aws-cdk/core')
 import { FoundationStack } from '../../lib/foundation'
 import { ManifestPipelineStack } from '../../lib/manifest-pipeline'
@@ -64,7 +64,8 @@ describe('MaintainMetadataStack', () => {
 
   describe('GraphQL', () => {
     test('creates a GraphQL API', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::GraphQLApi', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::GraphQLApi', {
         AuthenticationType: "OPENID_CONNECT",
         AdditionalAuthenticationProviders: [
           {
@@ -73,28 +74,31 @@ describe('MaintainMetadataStack', () => {
         ],
         Name: "MyTestStack-api",
         XrayEnabled: true,
-      }))
+      })
     })
 
     test('creates a GraphQL Schema', () => {
-      expectCDK(stack).to(haveResource('AWS::AppSync::GraphQLSchema'))
+      const template = Template.fromStack(stack)
+      template.resourceCountIs('AWS::AppSync::GraphQLSchema', 1)
     })
 
     test('creates a GraphQL API Key', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::ApiKey', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::ApiKey', {
         ApiId: {
           "Fn::GetAtt": [
             "ApiF70053CD",
             "ApiId",
           ],
         },
-      }))
+      })
     })
   }) /* end of describe GraphQL */
 
   describe('SSM Parameters', () => {
     test('creates SSMGraphqlApiUrl', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Value: {
           "Fn::GetAtt": [
@@ -104,7 +108,7 @@ describe('MaintainMetadataStack', () => {
         },
         Description: "AppSync GraphQL base url",
         Name: "/all/stacks/MyTestStack/graphql-api-url",
-      }))
+      })
     })
 
   }) /* end of describe SSM Parameters */
@@ -112,9 +116,10 @@ describe('MaintainMetadataStack', () => {
 
   describe('Data Sources', () => {
     test('creates WebsiteDynamoDataSource', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::DataSource', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::DataSource', {
         Name: "WebsiteDynamoDataSource",
-      }))
+      })
     })
 
   }) /* end of describe Data Sources */
@@ -122,42 +127,48 @@ describe('MaintainMetadataStack', () => {
 
   describe('Lambda', () => {
     test('creates RotateApiKeysLambdaFunction', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: "Rotates API Keys for AppSync - Maintain Metadata",
-      }))
+      })
     })
 
     test('creates RotateAPIKeysRule', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Events::Rule', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Events::Rule', {
         Description: "Start lambda to rotate API keys.",
-      }))
+      })
     })
 
   })
 
   describe('Functions', () => {
     test('creates GetMergedItemRecordFunction', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::FunctionConfiguration', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::FunctionConfiguration', {
         Name: "getMergedItemRecordFunction",
-      }))
+      })
     })
 
     test('creates ExpandSubjectTermsFunction', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::FunctionConfiguration', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::FunctionConfiguration', {
         Name: "expandSubjectTermsFunction",
-      }))
+      })
     })
 
     test('creates saveFileToProcessRecordFunction', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::FunctionConfiguration', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::FunctionConfiguration', {
         Name: "saveFileToProcessRecordFunction",
-      }))
+      })
     })
 
     test('creates updateImageRecordFunction', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::FunctionConfiguration', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::FunctionConfiguration', {
         Name: "updateImageRecordFunction",
-      }))
+      })
     })
 
   })
@@ -166,361 +177,414 @@ describe('MaintainMetadataStack', () => {
 
   describe('Resolvers', () => {
     test('creates ImageGroupImagesResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "ImageGroup",
         FieldName: "images",
-      }))
+      })
     })
 
     test('creates ImageImageGroupResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Image",
         FieldName: "imageGroup",
-      }))
+      })
     })
 
     test('creates ItemMetadataDefaultImageResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "ItemMetadata",
         FieldName: "defaultImage",
-      }))
+      })
     })
 
     test('creates ItemMetadataImagesResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "ItemMetadata",
         FieldName: "images",
-      }))
+      })
     })
 
     test('creates ItemMetadataMediaResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "ItemMetadata",
         FieldName: "media",
-      }))
+      })
     })
 
     test('creates MediaGroupMediaResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "MediaGroup",
         FieldName: "media",
-      }))
+      })
     })
 
     test('creates MediaMediaGroupResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Media",
         FieldName: "mediaGroup",
-      }))
+      })
     })
 
     test('creates ItemMetadataParentResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "ItemMetadata",
         FieldName: "parent",
-      }))
+      })
     })
 
     test('creates ItemMetadataChildrenResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "ItemMetadata",
         FieldName: "children",
-      }))
+      })
     })
 
     test('creates MutationAddItemToWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "addItemToWebsite",
-      }))
+      })
     })
 
     test('creates MutationRemoveMediaGroupForWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "removeMediaGroupForWebsite",
-      }))
+      })
     })
 
     test('creates MutationRemovePortfolioCollectionResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "removePortfolioCollection",
-      }))
+      })
     })
     test('creates MutationRemovePortfolioItemResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "removePortfolioItem",
-      }))
+      })
     })
     test('creates MutationgetRemovePortfolioUserResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "removePortfolioUser",
-      }))
+      })
     })
     test('creates MutationSavePortfolioCollectionResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "savePortfolioCollection",
-      }))
+      })
     })
     test('creates MutationSavePortfolioItemResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "savePortfolioItem",
-      }))
+      })
     })
     test('creates MutationsavePortfolioUserResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "savePortfolioUser",
-      }))
+      })
     })
 
 
     test('creates MutationAddItemToHarvestResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "addItemToHarvest",
-      }))
+      })
     })
 
     test('creates MutationRemoveItemFromWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "removeItemFromWebsite",
-      }))
+      })
     })
 
     test('creates MutationRemoveDefaultImageForWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "removeDefaultImageForWebsite",
-      }))
+      })
     })
 
     test('creates MutationSaveCopyrightForWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "saveCopyrightForWebsite",
-      }))
+      })
     })
 
     test('creates MutationSaveDefaultImageForWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "saveDefaultImageForWebsite",
-      }))
+      })
     })
 
     test('creates MutationSaveFileLastProcessedDateResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "saveFileLastProcessedDate",
-      }))
+      })
     })
 
     test('creates MutationSavePartiallyDigitizedForWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "savePartiallyDigitizedForWebsite",
-      }))
+      })
     })
 
     test('creates MutationSaveMediaGroupForWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Mutation",
         FieldName: "saveMediaGroupForWebsite",
-      }))
+      })
     })
 
     test('creates WebsiteItemItemMetadataResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "WebsiteItem",
         FieldName: "ItemMetadata",
-      }))
+      })
     })
 
     test('creates PortfolioUserPortfolioCollectionsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "PortfolioUser",
         FieldName: "portfolioCollections",
-      }))
+      })
     })
 
     test('creates PortfolioCollectionCreatorResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "PortfolioCollection",
         FieldName: "creator",
-      }))
+      })
     })
 
     test('creates QueryGetPortfolioCollectionResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getPortfolioCollection",
-      }))
+      })
     })
     test('creates QueryGetPortfolioItemResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getPortfolioItem",
-      }))
+      })
     })
     test('creates QueryGetPortfolioUserResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getPortfolioUser",
-      }))
+      })
     })
     test('creates QueryListImageGroupsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listImageGroups",
-      }))
+      })
     })
     test('creates QueryListImageGroupsForS3Resolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listImageGroupsForS3",
-      }))
+      })
     })
     test('creates QueryListImageGroupsReferencedResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listImageGroupsReferenced",
-      }))
+      })
     })
 
     test('creates QueryListMediaGroupsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listMediaGroups",
-      }))
+      })
     })
     test('creates QueryListMediaGroupsForS3Resolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listMediaGroupsForS3",
-      }))
+      })
     })
     test('creates QueryListMediaGroupsReferencedResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listMediaGroupsReferenced",
-      }))
+      })
     })
 
     test('creates QueryListPublicFeaturedPortfolioCollectionsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listPublicFeaturedPortfolioCollections",
-      }))
+      })
     })
     test('creates QueryListPublicHighlightedPortfolioCollectionsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listPublicHighlightedPortfolioCollections",
-      }))
+      })
     })
     test('creates QueryListPublicPortfolioCollectionsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listPublicPortfolioCollections",
-      }))
+      })
     })
 
     test('creates QueryGetFileToProcessRecordResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getFileToProcessRecord",
-      }))
+      })
     })
 
     test('creates QueryGetImageResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getImage",
-      }))
+      })
     })
 
     test('creates QueryGetImageGroupResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getImageGroup",
-      }))
+      })
     })
 
     test('creates QueryGetItemResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getItem",
-      }))
+      })
     })
 
     test('creates QueryGetMediaResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getMedia",
-      }))
+      })
     })
 
     test('creates QueryGetMediaGroupResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getMediaGroup",
-      }))
+      })
     })
 
     test('creates QueryGetWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "getWebsite",
-      }))
+      })
     })
 
     test('creates QueryListFilesToProcessResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listFilesToProcess",
-      }))
+      })
     })
 
     test('creates QueryListItemsBySourceSystemResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listItemsBySourceSystem",
-      }))
+      })
     })
 
     test('creates QueryListItemsByWebsiteResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listItemsByWebsite",
-      }))
+      })
     })
 
     test('creates QueryListSupplementalDataRecordsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listSupplementalDataRecords",
-      }))
+      })
     })
 
     test('creates QueryListWebsitesResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Query",
         FieldName: "listWebsites",
-      }))
+      })
     })
 
     test('creates WebsiteWebsiteItemsResolver', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::AppSync::Resolver', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::AppSync::Resolver', {
         TypeName: "Website",
         FieldName: "websiteItems",
-      }))
+      })
     })
 
   }) /* end of describe Resolvers */

--- a/deploy/cdk/test/manifest-lambda/stack.test.ts
+++ b/deploy/cdk/test/manifest-lambda/stack.test.ts
@@ -1,4 +1,4 @@
-import { expect as expectCDK, countResources, haveResourceLike } from '@aws-cdk/assert'
+import { Template } from '@aws-cdk/assertions'
 import { Bucket } from '@aws-cdk/aws-s3'
 import cdk = require('@aws-cdk/core')
 import { FoundationStack } from '../../lib/foundation'
@@ -83,58 +83,67 @@ describe('ManifestLambdaStack', () => {
   })
 
   test('creates iiifManifestLambda', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::Lambda::Function', {
       "Description": "Create iiif manifests real-time",
-    }))
+    })
   })
 
   test('creates an API Gateways for iiifManifestLambda and publicGraphqlLambda', () => {
-    expectCDK(stack).to(countResources('AWS::ApiGateway::Deployment', 2))
+    const template = Template.fromStack(stack)
+    template.resourceCountIs('AWS::ApiGateway::Deployment', 2)
   })
 
   test('creates an API Gateway Resource (manifest)', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::ApiGateway::Resource', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::ApiGateway::Resource', {
       "PathPart": "manifest",
-    }))
+    })
   })
 
 
   test('creates an API Gateway Resource (canvas)', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::ApiGateway::Resource', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::ApiGateway::Resource', {
       "PathPart": "canvas",
-    }))
+    })
   })
 
   test('creates an API Gateway Resource (annotation_page)', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::ApiGateway::Resource', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::ApiGateway::Resource', {
       "PathPart": "annotation_page",
-    }))
+    })
   })
 
   test('creates an API Gateway Resource (annotation)', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::ApiGateway::Resource', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::ApiGateway::Resource', {
       "PathPart": "annotation",
-    }))
+    })
   })
 
   test('creates an Route53 Recordset', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::Route53::RecordSet', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::Route53::RecordSet', {
       "Name": "test-iiif-manifest.test.edu.",
-    }))
+    })
   })
 
 
   test('creates a Lambda', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::Lambda::Function', {
       "Description": "Appends API keys and queries named AppSync resolvers",
-    }))
+    })
   })
 
 
   test('creates an API Gateway Resource (query)', () => {
-    expectCDK(stack).to(haveResourceLike('AWS::ApiGateway::Resource', {
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::ApiGateway::Resource', {
       "PathPart": "query",
-    }))
+    })
   })
 
 
@@ -147,7 +156,8 @@ describe('ManifestLambdaStack', () => {
         createDns: false,
       },
     })
-    expectCDK(testStack).notTo(haveResourceLike('AWS::Route53::RecordSet'))
+    const template = Template.fromStack(testStack)
+    template.resourceCountIs('AWS::Route53::RecordSet', 0)
   })
 
 }) /* end of describe ManifestPipelineStack */

--- a/deploy/cdk/test/manifest-pipeline/stack.test.ts
+++ b/deploy/cdk/test/manifest-pipeline/stack.test.ts
@@ -1,4 +1,4 @@
-import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert'
+import { Match, Template } from '@aws-cdk/assertions'
 import { Bucket } from '@aws-cdk/aws-s3'
 import cdk = require('@aws-cdk/core')
 import { FoundationStack } from '../../lib/foundation'
@@ -61,18 +61,20 @@ describe('ManifestPipelineStack', () => {
 
   describe('Buckets', () => {
     test('creates a Process Bucket', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::S3::Bucket', {
+      const template = Template.fromStack(stack)
+        template.hasResourceProperties('AWS::S3::Bucket', {
         LoggingConfiguration: {
           DestinationBucketName: {
             "Fn::ImportValue": "marble-foundation:ExportsOutputRefLogBucketCC3B17E818DCEC53",
           },
           LogFilePrefix: "s3/data-broker/",
         },
-      }))
+      })
     })
 
     test('creates a Manifest Bucket', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::S3::Bucket', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::S3::Bucket', {
         CorsConfiguration: {
           CorsRules: [
             {
@@ -94,75 +96,82 @@ describe('ManifestPipelineStack', () => {
           },
           LogFilePrefix: "s3/data-broker/",
         },
-      }))
+      })
     })
   }) /* end of describe Buckets */
 
   describe('SSM Parameters', () => {
     test('creates SSMImageServerBaseUrl', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Description: "Image server base url",
         Name: `${manifestPipelineContext.appConfigPath}/image-server-base-url`,
-      }))
+      })
     })
 
     test('creates SSMImageSourceBucket', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Value: {
           "Fn::ImportValue": "marble-foundation:ExportsOutputRefPublicBucketA6745C1519F3350E",
         },
         Description: "Image source bucket",
         Name: `${manifestPipelineContext.appConfigPath}/image-server-bucket`,
-      }))
+      })
     })
 
     test('creates SSMManifestServerBaseUrl', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Value: "presentation-iiif.test.edu",
         Description: "Manifest Server URL",
         Name: `${manifestPipelineContext.appConfigPath}/manifest-server-base-url`,
-      }))
+      })
     })
 
     test('creates SSMManifestBucket', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Value: {
           Ref: "ManifestBucket46C412A5",
         },
         Description: "S3 Bucket to hold Manifests",
         Name: `${manifestPipelineContext.appConfigPath}/manifest-server-bucket`,
-      }))
+      })
     })
 
     test('creates SSMProcessBucket', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Value: {
           Ref: "ProcessBucketE5460FC2",
         },
         Description: "S3 Bucket to accumulate assets during processing",
         Name: `${manifestPipelineContext.appConfigPath}/process-bucket`,
-      }))
+      })
     })
 
     test('creates SSMRBSCS3ImageBucketName', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::SSM::Parameter', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::SSM::Parameter', {
         Type: "String",
         Value: "libnd-smb-rbsc",
         Description: "Name of the RBSC Image Bucket",
         Name: `${ manifestPipelineContext.appConfigPath }/rbsc-image-bucket`,
-      }))
+      })
     })
   }) /* end of describe SSM Parameters */
 
 
   describe('Edge Lambda', () => {
     test('creates a Service Roll for the Edge Lambda ', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::IAM::Role', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::IAM::Role', {
         AssumeRolePolicyDocument: {
           Statement: [
             {
@@ -174,7 +183,7 @@ describe('ManifestPipelineStack', () => {
             },
           ],
         },
-      }))
+      })
     })
 
   }) /* end of describe Lambdas */
@@ -182,45 +191,52 @@ describe('ManifestPipelineStack', () => {
 
   describe('Lambdas', () => {
     test('creates MuseumExportLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Creates standard json from web-enabled items from Web Kiosk.',
-      }))
+      })
     })
 
     test('creates CopyMediaContentLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Copies media files from other folders to /public-access/media folder to be served by CDN',
-      }))
+      })
     })
 
     test('creates AlephExportLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Creates standard json from Aleph records with 500$a = MARBLE.',
-      }))
+      })
     })
 
     test('creates ArchivesSpaceExportLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Creates standard json from a list of ArchivesSpace urls.',
-      }))
+      })
     })
 
     test('creates CurateExportLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Creates standard json from a list of curate PIDs.',
-      }))
+      })
     })
 
     test('creates ExpandSubjectTermsLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Cycles through subject term URIs stored in dynamo, and expands those subject terms using the appropriate online authority.',
-      }))
+      })
     })
 
     test('creates ObjectFilesApiLambda', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::Lambda::Function', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::Lambda::Function', {
         Description: 'Creates json representations files to be used by Red Box.',
-      }))
+      })
     })
 
 
@@ -230,7 +246,8 @@ describe('ManifestPipelineStack', () => {
 
   describe('State Machines', () => {
     test('creates HarvestStateMachine ', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::StepFunctions::StateMachine', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::StepFunctions::StateMachine', {
         "DefinitionString": {
           "Fn::Join": [
             "",
@@ -305,7 +322,7 @@ describe('ManifestPipelineStack', () => {
             ],
           ],
         },
-      }))
+      })
     })
 
   }) /* end of describe StateMachines */
@@ -322,10 +339,11 @@ describe('ManifestPipelineStack', () => {
       })
 
       test('creates StartStdJsonHarvestRule ', () => {
-        expectCDK(stack).to(haveResourceLike('AWS::Events::Rule', {
+        const template = Template.fromStack(stack)
+        template.hasResourceProperties('AWS::Events::Rule', {
           Description: "Start State Machine harvest of source systems to create standard json.",
           ScheduleExpression: "cron(0 6 * * ? *)",
-        }))
+        })
       })
     }) /* end of describe when createEventRules is true */
 
@@ -337,11 +355,10 @@ describe('ManifestPipelineStack', () => {
         })
       })
 
-      test('creates StartStdJsonHarvestRule ', () => {
-        expectCDK(stack).notTo(haveResourceLike('AWS::Events::Rule', {
-          Description: "Start State Machine harvest of source systems to create standard json.",
-          ScheduleExpression: "cron(0 6 * * ? *)",
-        }))
+      test('does not create StartStdJsonHarvestRule ', () => {
+        const template = Template.fromStack(stack)
+        template.resourceCountIs('AWS::Events::Rule', 0)
+
       })
     }) /* end of describe when createEventRules is false */
 
@@ -352,7 +369,8 @@ describe('ManifestPipelineStack', () => {
 
   describe('dynamoDB tables', () => {
     test('creates websiteMetadataDynamoTable ', () => {
-      expectCDK(stack).to(haveResourceLike('AWS::DynamoDB::Table', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
         "KeySchema": [
           {
             "AttributeName": "PK",
@@ -386,6 +404,14 @@ describe('ManifestPipelineStack', () => {
           },
           {
             "AttributeName": "GSI2SK",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "GSI3PK",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "GSI3SK",
             "AttributeType": "S",
           },
         ],
@@ -423,6 +449,22 @@ describe('ManifestPipelineStack', () => {
               "ProjectionType": "ALL",
             },
           },
+          {
+            "IndexName": "GSI3",
+            "KeySchema": [
+              {
+                "AttributeName": "GSI3PK",
+                "KeyType": "HASH",
+              },
+              {
+                "AttributeName": "GSI3SK",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
         ],
         "PointInTimeRecoverySpecification": {
           "PointInTimeRecoveryEnabled": true,
@@ -431,18 +473,14 @@ describe('ManifestPipelineStack', () => {
           "AttributeName": "expireTime",
           "Enabled": true,
         },
-      }))
+      })
     })
 
     test('does not create tags for websiteMetadataDynamoTable ', () => {
-      expectCDK(stack).notTo(haveResourceLike('AWS::DynamoDB::Table', {
-        "Tags": [
-          {
-            "Key": "BackupMarbleDynamoDB",
-            "Value": "true",
-          },
-        ],
-      }))
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        "Tags": Match.absent(),
+      })
     })
 
     test('creates tags for DynamoDB table', () => {
@@ -459,14 +497,15 @@ describe('ManifestPipelineStack', () => {
         ...manifestPipelineContext,
         createBackup: true,
       })
-      expectCDK(stack).to(haveResourceLike('AWS::DynamoDB::Table', {
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
         "Tags": [
           {
             "Key": "BackupMarbleDynamoDB",
             "Value": "true",
           },
         ],
-      }))
+      })
 
     })
 

--- a/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
+++ b/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
@@ -43,8 +43,8 @@ describe('MultimediaAssetsStack', () => {
                 '*.fake.domain',
               ],
               MaxAge: 3600,
-            }
-          ]
+            },
+          ],
         },
         LoggingConfiguration: {
           DestinationBucketName: {

--- a/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
+++ b/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
@@ -1,4 +1,4 @@
-import { expect as expectCDK, haveResourceLike, stringLike } from '@aws-cdk/assert'
+import { Match, Template } from '@aws-cdk/assertions'
 import cdk = require('@aws-cdk/core')
 import { FoundationStack } from '../../lib/foundation'
 import { MultimediaAssetsStack } from '../../lib/multimedia-assets'
@@ -27,76 +27,73 @@ describe('MultimediaAssetsStack', () => {
   })
 
   test('creates an s3 bucket for assets', () => {
-    expectCDK(stack).to(
-      haveResourceLike('AWS::S3::Bucket', {
-        BucketName: 'my-happy-place-multimedia-123456789',
-        CorsConfiguration: {
-          CorsRules: [
-            {
-              AllowedHeaders: [
-                '*',
-              ],
-              AllowedMethods: [
-                'GET',
-              ],
-              AllowedOrigins: [
-                '*.fake.domain',
-              ],
-              MaxAge: 3600,
-            },
-          ],
-        },
-        LoggingConfiguration: {
-          DestinationBucketName: {
-            'Fn::ImportValue': stringLike('FoundationStack:ExportsOutputRefLogBucket*'),
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: 'my-happy-place-multimedia-123456789',
+      CorsConfiguration: {
+        CorsRules: [
+          {
+            AllowedHeaders: [
+              '*',
+            ],
+            AllowedMethods: [
+              'GET',
+            ],
+            AllowedOrigins: [
+              '*.fake.domain',
+            ],
+            MaxAge: 3600,
           },
-          LogFilePrefix: 's3/data-broker/',
+        ],
+      },
+      LoggingConfiguration: {
+        DestinationBucketName: {
+          'Fn::ImportValue': Match.stringLikeRegexp('^FoundationStack:ExportsOutputRefLogBucket*'),
         },
-        PublicAccessBlockConfiguration: {
-          BlockPublicAcls: true,
-          BlockPublicPolicy: true,
-          IgnorePublicAcls: true,
-          RestrictPublicBuckets: true,
-        },
-      }),
-    )
+        LogFilePrefix: 's3/data-broker/',
+      },
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    })
   })
 
   test('creates a cloudfront with an appropriate domain name', () => {
-    expectCDK(stack).to(
-      haveResourceLike('AWS::CloudFront::Distribution', {
-        DistributionConfig: {
-          Aliases: [
-            'my-happy-place-multimedia.fake.domain',
-          ],
-          DefaultCacheBehavior: {
-            DefaultTTL: 9001,
-            ViewerProtocolPolicy: 'redirect-to-https',
-          },
-          ViewerCertificate: {
-            AcmCertificateArn: {
-              'Fn::ImportValue': stringLike('FoundationStack:ExportsOutputRefCertificate*'),
-            },
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: {
+        Aliases: [
+          'my-happy-place-multimedia.fake.domain',
+        ],
+        DefaultCacheBehavior: {
+          DefaultTTL: 9001,
+          ViewerProtocolPolicy: 'redirect-to-https',
+        },
+        ViewerCertificate: {
+          AcmCertificateArn: {
+            'Fn::ImportValue': Match.stringLikeRegexp('^FoundationStack:ExportsOutputRefCertificate*'),
           },
         },
-      }),
-    )
+      },
+    })
   })
 
   test('creates a route53 record for the domain', () => {
-    expectCDK(stack).to(
-      haveResourceLike('AWS::Route53::RecordSet', {
-        Name: 'my-happy-place-multimedia.fake.domain.',
-        Type: 'CNAME',
-        HostedZoneId: {
-          'Fn::ImportValue': stringLike('FoundationStack:ExportsOutputRefHostedZone*'),
+    const template = Template.fromStack(stack)
+    template.hasResourceProperties('AWS::Route53::RecordSet', {
+      Name: 'my-happy-place-multimedia.fake.domain.',
+      Type: 'CNAME',
+      HostedZoneId: {
+        'Fn::ImportValue': Match.stringLikeRegexp('^FoundationStack:ExportsOutputRefHostedZone*'),
+      },
+      ResourceRecords: [
+        {
+          'Fn::GetAtt': ['DistributionCFDistribution882A7313', 'DomainName'],
         },
-        ResourceRecords: [
-          {
-            'Fn::GetAtt': ['DistributionCFDistribution882A7313', 'DomainName'],
-          },
-        ],
-      }),
-    )
+      ],
+    })
   })
 })

--- a/deploy/cdk/yarn.lock
+++ b/deploy/cdk/yarn.lock
@@ -10,16 +10,6 @@
     "@aws-cdk/core" "1.141.0"
     constructs "^3.3.69"
 
-"@aws-cdk/assert@1.141.0":
-  version "1.141.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.141.0.tgz#653d3f4ce74499ba728fb89eba7ba4c6c32bea78"
-  integrity sha512-pQh/XUzHt2+6NQ4Ix8EehZJHw5oIli2z3kGkXmKPyeNZ/U9h7IAPL6x03Q6TqETXI4eogFXyl5tDIFSF4eNEcA==
-  dependencies:
-    "@aws-cdk/cloudformation-diff" "1.141.0"
-    "@aws-cdk/core" "1.141.0"
-    "@aws-cdk/cx-api" "1.141.0"
-    constructs "^3.3.69"
-
 "@aws-cdk/assertions@^1.141.0":
   version "1.141.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/assertions/-/assertions-1.141.0.tgz#656e3989dc812c257f78be9045b0a4cf6c40a21d"


### PR DESCRIPTION
* Migrated tests from @aws-cdk/assert to @aws-cdk/assertions to prepare for migration to CDK 2.x