### PR TITLE
Fixed CDK2 bucket permissions

### DIFF
--- a/deploy/cdk/lib/cdk-pipeline-deploy.ts
+++ b/deploy/cdk/lib/cdk-pipeline-deploy.ts
@@ -162,7 +162,7 @@ export class CDKPipelineDeploy extends Construct {
         's3:GetBucketLocation',
         's3:GetBucketPolicy',
       ],
-      resources: [ 'arn:aws:s3:::cdktoolkit-stagingbucket-*' ],
+      resources: ['arn:aws:s3:::cdktoolkit-stagingbucket-*', 'arn:aws:s3:::cdk*' ],
     }))
 
     this.action = new CodeBuildAction({

--- a/deploy/cdk/lib/static-host/pipeline-s3-sync.ts
+++ b/deploy/cdk/lib/static-host/pipeline-s3-sync.ts
@@ -218,7 +218,7 @@ export class PipelineS3Sync extends Construct {
         's3:GetBucketLocation',
         's3:GetBucketPolicy',
       ],
-      resources: [ 'arn:aws:s3:::cdktoolkit-stagingbucket-*' ],
+      resources: ['arn:aws:s3:::cdktoolkit-stagingbucket-*', 'arn:aws:s3:::cdk*' ],
     }))
     this.project.addToRolePolicy(new PolicyStatement({
       actions: [


### PR DESCRIPTION
* Added access to bucket starting with cdk*.  The marble pipelines now deploy correctly.