### PR TITLE
Add dockerhub credentials

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -39,6 +39,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     infraRepoOwner: getRequiredContext(app.node, 'infraRepoOwner'),
     infraRepoName: getRequiredContext(app.node, 'infraRepoName'),
     infraSourceBranch: getRequiredContext(app.node, 'infraSourceBranch'),
+    dockerhubCredentialsPath: getRequiredContext(app.node, 'dockerhubCredentialsPath'),
   }
 
   const staticHostContext = getContextByNamespace('staticHost')

--- a/deploy/cdk/lib/cdk-pipeline-deploy.ts
+++ b/deploy/cdk/lib/cdk-pipeline-deploy.ts
@@ -51,7 +51,7 @@ export interface ICDKPipelineDeployProps extends PipelineProjectProps {
   readonly outputDirectory?: string;
   readonly outputFiles?: string[];
   readonly outputArtifact?: Artifact;
-  readonly dockerhubCredentialsPath?: string;
+  readonly dockerhubCredentialsPath: string;
   /**
    * Any runtime environments needed in addition to the one needed for cdk itself (currently nodejs: '14.x')  e.g. `python: '3.9'`
    */
@@ -106,6 +106,7 @@ export class CDKPipelineDeploy extends Construct {
           pre_build: {
             commands: [
               `cd ${appSourceDir}`,
+              'echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin',
               ...(props.appBuildCommands || []),
             ],
           },
@@ -197,13 +198,17 @@ export class CDKPipelineDeploy extends Construct {
       runOrder: 1,
       outputs: (props.outputArtifact ? [props.outputArtifact] : []),
       environmentVariables: {
+        DOCKERHUB_CREDENTIALS_PATH: {
+          type: BuildEnvironmentVariableType.PLAINTEXT,
+          value: props.dockerhubCredentialsPath || '',
+        },
         DOCKERHUB_USERNAME: {
           type: BuildEnvironmentVariableType.SECRETS_MANAGER,
-          value: props.dockerhubCredentialsPath + ':username',
+          value: `${props.dockerhubCredentialsPath}:username`,
         },
         DOCKERHUB_PASSWORD: {
           type: BuildEnvironmentVariableType.SECRETS_MANAGER,
-          value: props.dockerhubCredentialsPath + ':password',
+          value: `${props.dockerhubCredentialsPath}:password`,
         },
       },
 })

--- a/deploy/cdk/lib/cdk-pipeline-deploy.ts
+++ b/deploy/cdk/lib/cdk-pipeline-deploy.ts
@@ -1,4 +1,4 @@
-import { BuildSpec, LinuxBuildImage, PipelineProject, PipelineProjectProps } from 'aws-cdk-lib/aws-codebuild'
+import { BuildEnvironmentVariableType, BuildSpec, LinuxBuildImage, PipelineProject, PipelineProjectProps } from 'aws-cdk-lib/aws-codebuild'
 import { Artifact } from 'aws-cdk-lib/aws-codepipeline'
 import { CodeBuildAction } from 'aws-cdk-lib/aws-codepipeline-actions'
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam'
@@ -51,7 +51,7 @@ export interface ICDKPipelineDeployProps extends PipelineProjectProps {
   readonly outputDirectory?: string;
   readonly outputFiles?: string[];
   readonly outputArtifact?: Artifact;
-
+  readonly dockerhubCredentialsPath: string;
   /**
    * Any runtime environments needed in addition to the one needed for cdk itself (currently nodejs: '14.x')  e.g. `python: '3.9'`
    */
@@ -196,6 +196,16 @@ export class CDKPipelineDeploy extends Construct {
       project: this.project,
       runOrder: 1,
       outputs: (props.outputArtifact ? [props.outputArtifact] : []),
-    })
+      environmentVariables: {
+        DOCKERHUB_USERNAME: {
+          type: BuildEnvironmentVariableType.SECRETS_MANAGER,
+          value: props.dockerhubCredentialsPath + ':username',
+        },
+        DOCKERHUB_PASSWORD: {
+          type: BuildEnvironmentVariableType.SECRETS_MANAGER,
+          value: props.dockerhubCredentialsPath + ':password',
+        },
+      },
+})
   }
 }

--- a/deploy/cdk/lib/cdk-pipeline-deploy.ts
+++ b/deploy/cdk/lib/cdk-pipeline-deploy.ts
@@ -51,7 +51,7 @@ export interface ICDKPipelineDeployProps extends PipelineProjectProps {
   readonly outputDirectory?: string;
   readonly outputFiles?: string[];
   readonly outputArtifact?: Artifact;
-  readonly dockerhubCredentialsPath: string;
+  readonly dockerhubCredentialsPath?: string;
   /**
    * Any runtime environments needed in addition to the one needed for cdk itself (currently nodejs: '14.x')  e.g. `python: '3.9'`
    */

--- a/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
+++ b/deploy/cdk/lib/iiif-serverless/deployment-pipeline.ts
@@ -37,6 +37,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
   readonly paramPathPrefix: string;
+  readonly dockerhubCredentialsPath: string;
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -97,6 +98,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: "IIIF Serverless API",
           projectName: "marble",

--- a/deploy/cdk/lib/image-processing/deployment-pipeline.ts
+++ b/deploy/cdk/lib/image-processing/deployment-pipeline.ts
@@ -33,6 +33,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly createGithubWebhooks: boolean;
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
+  readonly dockerhubCredentialsPath: string;
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -53,6 +54,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: "Image processing",
           projectName: "marble",

--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -25,6 +25,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
   readonly createGithubWebhooks: boolean;
+  readonly dockerhubCredentialsPath: string;
  }
 
 
@@ -51,6 +52,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: "data pipeline for maintaining metadata",
           projectName: "marble",

--- a/deploy/cdk/lib/manifest-lambda/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-lambda/deployment-pipeline.ts
@@ -34,6 +34,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly publicGraphqlHostnamePrefix: string;
   readonly testFoundationStack: FoundationStack
   readonly prodFoundationStack: FoundationStack
+  readonly dockerhubCredentialsPath: string;
  }
 
 
@@ -66,6 +67,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: "data pipeline for creating manifest lambda",
           projectName: "marble",

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -39,6 +39,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly prodMetadataTimeToLiveDays: string;
   readonly filesTimeToLiveDays: string;
   readonly prodFilesTimeToLiveDays: string;
+  readonly dockerhubCredentialsPath: string;
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -70,6 +71,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: "data pipeline for IIIF Manifests",
           projectName: "marble",

--- a/deploy/cdk/lib/multimedia-assets/deployment-pipeline.ts
+++ b/deploy/cdk/lib/multimedia-assets/deployment-pipeline.ts
@@ -30,6 +30,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly prodFoundationStack: FoundationStack
   readonly hostnamePrefix: string
   readonly createDns: boolean
+  readonly dockerhubCredentialsPath: string;
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -51,6 +52,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: props.description,
           projectName: props.projectName,

--- a/deploy/cdk/lib/opensearch/deployment-pipeline.ts
+++ b/deploy/cdk/lib/opensearch/deployment-pipeline.ts
@@ -23,6 +23,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly createGithubWebhooks: boolean;
   readonly slackNotifyStackName?: string;
   readonly notificationReceivers?: string;
+  readonly dockerhubCredentialsPath: string;
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -42,6 +43,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace: `${namespace}`,
         contextEnvName: contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: {
           description: "Opensearch cluster",
           projectName: "marble",

--- a/deploy/cdk/lib/opensearch/opensearch-stack.ts
+++ b/deploy/cdk/lib/opensearch/opensearch-stack.ts
@@ -34,7 +34,7 @@ export class OpenSearchStack extends Stack {
 
     this.domain = new Domain(this, `${props.namespace}-domain`, {
       enableVersionUpgrade: true,
-      version: EngineVersion.OPENSEARCH_1_0,
+      version: EngineVersion.OPENSEARCH_1_2,
       capacity: {
         masterNodes: masterNodes,
         masterNodeInstanceType: masterNodeInstanceType,

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -57,6 +57,7 @@ export interface IDeploymentPipelineStackProps extends StackProps {
   readonly authClientUrl: string
   readonly authClientId: string
   readonly authClientIssuer: string
+  readonly dockerhubCredentialsPath: string;
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -101,6 +102,7 @@ export class DeploymentPipelineStack extends Stack {
         cdkDirectory: 'deploy/cdk',
         namespace,
         contextEnvName: props.contextEnvName,
+        dockerhubCredentialsPath: props.dockerhubCredentialsPath,
         additionalContext: additionalContext,
       })
       cdkDeploy.project.addToRolePolicy(new PolicyStatement({


### PR DESCRIPTION
* Added dockerhub credentials to pipeline deployments to avoid error of "toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
* Bumped version of OpenSearch from 1.0 to 1.2 (which is what we're actually using in production)