### PR TITLE
Restore missing lines.

### DIFF
--- a/deploy/cdk/lib/maintain-metadata/maintain-metadata-stack.ts
+++ b/deploy/cdk/lib/maintain-metadata/maintain-metadata-stack.ts
@@ -1482,6 +1482,8 @@ def _delete_expired_api_keys(graphql_api_id: str):
         $!{expValues.put(":layout", $util.dynamodb.toDynamoDB($layout))}
         $!{expValues.put(":title", $util.dynamodb.toDynamoDB($title))}
         $!{expValues.put(":privacy", $util.dynamodb.toDynamoDB($privacy))}
+        $!{expValues.put(":GSI1PK", $util.dynamodb.toDynamoDB("PORTFOLIOCOLLECTION"))}
+        $!{expValues.put(":GSI1SK", $util.dynamodb.toDynamoDB("PORTFOLIOCOLLECTION#$portfolioCollectionId"))}
 
         #if( $privacy == "private" )
           #set($GSI2PK = "")


### PR DESCRIPTION
These lines were found in production and are apparently necessary for the save portfolio resolver to work correctly. A change was made on an old branch on Oct 15, 2021, that was deployed to production (apparently), but never merged to master.

**Note:** 
Stale branch with same changes that was presumably deployed: https://github.com/ndlib/marble-blueprints/commit/d22455ae0cb0b127f454490ceeed60aac52951d1