### PR TITLE
Create DNS entries

### DIFF
--- a/deploy/cdk/lib/foundation/foundation-stack.ts
+++ b/deploy/cdk/lib/foundation/foundation-stack.ts
@@ -111,6 +111,11 @@ export class FoundationStack extends Stack {
       validation: certificateValidation,
     })
 
+    new CfnOutput(this, 'ExportsOutputRefCertificate4E7ABB08F7C8AF50', {
+      value: this.certificate.certificateArn,
+      exportName: `${this.stackName}:ExportsOutputRefCertificate4E7ABB08F7C8AF50`,
+    })
+
     const certificateArnPath = `/all/dns/${props.domainName}/certificateArn`
     this.certificateArn = StringParameter.valueForStringParameter(this, certificateArnPath)
 

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -4,6 +4,7 @@ import { BuildSpec, LinuxBuildImage, PipelineProject, BuildEnvironmentVariableTy
 import { CodeBuildAction, GitHubTrigger } from 'aws-cdk-lib/aws-codepipeline-actions'
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam'
 import { Topic } from 'aws-cdk-lib/aws-sns'
+import { StringParameter } from 'aws-cdk-lib/aws-ssm'
 import { Fn, SecretValue, Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import { SlackApproval, PipelineNotifications } from '@ndlib/ndlib-cdk2'
@@ -14,32 +15,33 @@ import { GithubApproval } from '../github-approval'
 
 export interface IDeploymentPipelineStackProps extends StackProps {
   readonly pipelineFoundationStack: PipelineFoundationStack
-  readonly oauthTokenPath: string; // Note:  This is a secretstore value, not an ssm value /esu/github/ndlib-git
-  readonly appRepoOwner: string;
-  readonly appRepoName: string;
-  readonly appSourceBranch: string;
-  readonly infraRepoOwner: string;
-  readonly infraRepoName: string;
-  readonly infraSourceBranch: string;
-  readonly namespace: string;
-  readonly contextEnvName: string;
-  readonly owner: string;
-  readonly contact: string;
-  readonly slackNotifyStackName?: string;
-  readonly notificationReceivers?: string;
-  readonly hostnamePrefix: string;
-  readonly createDns: boolean;
-  readonly sentryDsn: string;
-  readonly imageServiceStackName: string;
-  readonly dataProcessingKeyPath: string;
-  readonly prodImageServiceStackName: string;
-  readonly prodDataProcessingKeyPath: string;
-  readonly createGithubWebhooks: boolean;
-  readonly metadataTimeToLiveDays: string;
-  readonly prodMetadataTimeToLiveDays: string;
-  readonly filesTimeToLiveDays: string;
-  readonly prodFilesTimeToLiveDays: string;
-  readonly dockerhubCredentialsPath: string;
+  readonly oauthTokenPath: string // Note:  This is a secretstore value, not an ssm value /esu/github/ndlib-git
+  readonly appRepoOwner: string
+  readonly appRepoName: string
+  readonly appSourceBranch: string
+  readonly infraRepoOwner: string
+  readonly infraRepoName: string
+  readonly infraSourceBranch: string
+  readonly namespace: string
+  readonly contextEnvName: string
+  readonly owner: string
+  readonly contact: string
+  readonly slackNotifyStackName?: string
+  readonly notificationReceivers?: string
+  readonly hostnamePrefix: string
+  readonly sentryDsn: string
+  readonly imageServiceStackName: string
+  readonly dataProcessingKeyPath: string
+  readonly prodImageServiceStackName: string
+  readonly prodDataProcessingKeyPath: string
+  readonly createGithubWebhooks: boolean
+  readonly metadataTimeToLiveDays: string
+  readonly prodMetadataTimeToLiveDays: string
+  readonly filesTimeToLiveDays: string
+  readonly prodFilesTimeToLiveDays: string
+  readonly dockerhubCredentialsPath: string
+  readonly domainName: string
+  readonly hostedZoneTypes: string
 }
 
 export class DeploymentPipelineStack extends Stack {
@@ -181,9 +183,13 @@ export class DeploymentPipelineStack extends Stack {
         ],
       }))
 
-      if(props.createDns){
-        cdkDeploy.project.addToRolePolicy(NamespacedPolicy.route53RecordSet('*'))
+      // Grant permission for creating DNS
+      for (const hostedZoneType of props.hostedZoneTypes) {
+        const hostedZoneIdPath = `/all/dns/${props.domainName}/${hostedZoneType}/zoneId`
+        const hostedZoneId = StringParameter.valueForStringParameter(this, hostedZoneIdPath)
+        cdkDeploy.project.addToRolePolicy(NamespacedPolicy.route53RecordSet(hostedZoneId))
       }
+
       return cdkDeploy
     }
 

--- a/deploy/cdk/lib/manifest-pipeline/manifest-pipeline-stack.ts
+++ b/deploy/cdk/lib/manifest-pipeline/manifest-pipeline-stack.ts
@@ -21,12 +21,12 @@ export interface IBaseStackProps extends StackProps {
   /**
    * The name of the foundation stack upon which this stack is dependent
    */
-  readonly foundationStack: FoundationStack;
+  readonly foundationStack: FoundationStack
 
   /**
    * The domain name to use to reference and create Parameter Store parameters
    */
-  readonly domainName: string;
+  readonly domainName: string
 
   /**
    * The host name of the IIIF Image Server
@@ -36,99 +36,94 @@ export interface IBaseStackProps extends StackProps {
   /**
    * The ssm path to look for the marble data processing config from
    */
-  readonly marbleProcessingKeyPath: string;
+  readonly marbleProcessingKeyPath: string
 
   /**
    * Email address notification emails are sent from
    */
-  readonly noReplyEmailAddr: string;
+  readonly noReplyEmailAddr: string
 
   /**
    * The sentry data source name (DSN)
    */
-  readonly sentryDsn: string;
+  readonly sentryDsn: string
 
   /**
    * The name of the bucket that rarebooks images are in for the search process
    */
-  readonly rBSCS3ImageBucketName: string;
+  readonly rBSCS3ImageBucketName: string
 
   /**
    * The name of the bucket that contains marble content
    */
-  readonly marbleContentBucketName: string;
+  readonly marbleContentBucketName: string
 
   /**
    * S3 bucket where multimedia assets are stored (created by multimedia-assets stack)
    */
-  readonly multimediaBucket: Bucket;
+  readonly multimediaBucket: Bucket
 
   /**
    * The ssm path to look for the google team drive credentials and drive-id
    */
-  readonly googleKeyPath: string;
+  readonly googleKeyPath: string
 
   /**
    * The ssm path to look for the EmbARK museum credentials
    */
-  readonly museumKeyPath: string;
+  readonly museumKeyPath: string
 
   /**
    * The ssm path to look for the CurateND credentials
    */
-  readonly curateKeyPath: string;
-
-  /**
-   * If True, will attempt to create a Route 53 DNS record for the CloudFront.
-   */
-  readonly createDns: boolean;
+  readonly curateKeyPath: string
 
   /**
    * Hostname prefix for the manifest bucket CDN
    */
-  readonly hostnamePrefix: string;
+  readonly hostnamePrefix: string
 
   /**
    * If True, will attempt to create a Rule to harvest metadata and create standard json.
    */
-  readonly createEventRules: boolean;
+  readonly createEventRules: boolean
 
   /**
    * The filesystem root where we can find the source code for all our lambdas.
    * e.g.  /user/me/source/marble-manifest-pipeline/
    * The path for each individual lambda will be appended to this.
    */
-  readonly lambdaCodeRootPath: string;
+  readonly lambdaCodeRootPath: string
 
   /**
    * The ssm path to look for the application config from
    */
-  readonly appConfigPath: string;
+  readonly appConfigPath: string
 
   /**
    * The time to live for records in the metadata dynamodb table
    */
-  readonly metadataTimeToLiveDays: string;
+  readonly metadataTimeToLiveDays: string
 
   /**
    * The time to live for records in the files dynamodb table
    */
-  readonly filesTimeToLiveDays: string;
+  readonly filesTimeToLiveDays: string
 
   /**
    * This will create the CopyMediaContentLambda if true, otherwise it won't.
    */
-  readonly createCopyMediaContentLambda?: boolean;
+  readonly createCopyMediaContentLambda?: boolean
 
   /**
    * The fileShareId for the Marble Content Storage Gateway.  This will be used to create the File Share ARN to pass to the CopyMediaLambda
    */
-  readonly marbleContentFileShareId: string;
+  readonly marbleContentFileShareId: string
 
   /**
      * The flag to determine if a backup should be added to the dynamo table.
      */
-  readonly createBackup?: boolean;
+  readonly createBackup?: boolean
 }
 
 export class ManifestPipelineStack extends Stack {

--- a/deploy/cdk/test/maintain-metadata/stack.test.ts
+++ b/deploy/cdk/test/maintain-metadata/stack.test.ts
@@ -32,6 +32,7 @@ const manifestPipelineContext = {
   metadataTimeToLiveDays: "365",
   filesTimeToLiveDays: "365",
   marbleContentFileShareId: "some fake arn",
+  hostedZoneTypes: ['public'],
 }
 
 const maintainMetadataContext = {

--- a/deploy/cdk/test/manifest-lambda/stack.test.ts
+++ b/deploy/cdk/test/manifest-lambda/stack.test.ts
@@ -32,6 +32,7 @@ const manifestPipelineContext = {
   metadataTimeToLiveDays: "365",
   filesTimeToLiveDays: "365",
   marbleContentFileShareId: "some fake arn",
+  hostedZoneTypes: ['public'],
 }
 
 const maintainMetadataContext = {
@@ -45,6 +46,7 @@ const manifestLambdaContext = {
   hostnamePrefix: 'test-iiif-manifest',
   lambdaCodeRootPath: "../../../marble-manifest-lambda",
   publicGraphqlHostnamePrefix: "sample-public-graphql",
+  hostedZoneTypes: ['public'],
 }
 
 const setup = (props: { manifestPipelineContext: any, maintainMetadataContext: any, manifestLambdaContext: any }) => {
@@ -144,20 +146,6 @@ describe('ManifestLambdaStack', () => {
     template.hasResourceProperties('AWS::ApiGateway::Resource', {
       "PathPart": "query",
     })
-  })
-
-
-  test('does not create an Route53 Recordset when createDns is false', () => {
-    const testStack = setup({
-      manifestPipelineContext,
-      maintainMetadataContext,
-      manifestLambdaContext: {
-        ...manifestLambdaContext,
-        createDns: false,
-      },
-    })
-    const template = Template.fromStack(testStack)
-    template.resourceCountIs('AWS::Route53::RecordSet', 0)
   })
 
 }) /* end of describe ManifestPipelineStack */

--- a/deploy/cdk/test/manifest-pipeline/stack.test.ts
+++ b/deploy/cdk/test/manifest-pipeline/stack.test.ts
@@ -33,6 +33,7 @@ const manifestPipelineContext = {
   createCopyMediaContentLambda: true,
   marbleContentFileShareId: "some fake arn",
   createBackup: false,
+  hostedZoneTypes: ['public'],
 }
 
 const setup = (context: any) => {

--- a/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
+++ b/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
@@ -19,11 +19,11 @@ describe('MultimediaAssetsStack', () => {
     env,
     foundationStack,
     domainName,
-    createDns: true,
     namespace: 'my-happy-place',
     cacheTtl: 9001,
     stackName: 'test-stack-name',
     marbleContentBucketName: 'libnd-smb-marble',
+    hostedZoneTypes: ['public'],
   })
 
   test('creates an s3 bucket for assets', () => {
@@ -74,7 +74,7 @@ describe('MultimediaAssetsStack', () => {
         },
         ViewerCertificate: {
           AcmCertificateArn: {
-            'Fn::ImportValue': Match.stringLikeRegexp('^FoundationStack:ExportsOutputRefCertificate*'),
+            'Fn::ImportValue': Match.stringLikeRegexp('^FoundationStack:ExportsOutputRefSsmParameterValuealldns*'),
           },
         },
       },
@@ -86,14 +86,16 @@ describe('MultimediaAssetsStack', () => {
     template.hasResourceProperties('AWS::Route53::RecordSet', {
       Name: 'my-happy-place-multimedia.fake.domain.',
       Type: 'CNAME',
+      Comment: 'my-happy-place-multimedia.fake.domain',
       HostedZoneId: {
-        'Fn::ImportValue': Match.stringLikeRegexp('^FoundationStack:ExportsOutputRefHostedZone*'),
+        'Ref': Match.stringLikeRegexp('^SsmParameterValuealldnsfakedomainpubliczone*'),
       },
       ResourceRecords: [
         {
           'Fn::GetAtt': ['DistributionCFDistribution882A7313', 'DomainName'],
         },
       ],
+      TTL: '900',
     })
   })
 })


### PR DESCRIPTION
* Changed pipelines to grant access to create DNS entries for the hosted zones saved in parameter store.
* Changed stacks to create DNS entries in the hosted zones defined by hostedZoneTypes in combination with parameter store values.
* Changed to use CertificateArn from foundation-stack instead of certificate export
* Note: This is PR 2 of 3.  The final one will clean up residual DNS, certificate, and hostedZone items that are no longer needed.