### PR TITLE
Make test stages private

### DIFF
--- a/deploy/cdk/bin/codepipelines.ts
+++ b/deploy/cdk/bin/codepipelines.ts
@@ -39,6 +39,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     infraSourceBranch: getRequiredContext(app.node, 'infraSourceBranch'),
     dockerhubCredentialsPath: getRequiredContext(app.node, 'dockerhubCredentialsPath'),
     hostedZoneTypes: contextEnv.hostedZoneTypes,
+    hostedZoneTypesTest: contextEnv.hostedZoneTypesTest,
     domainName: contextEnv.domainName,
   }
 

--- a/deploy/cdk/bin/services.ts
+++ b/deploy/cdk/bin/services.ts
@@ -34,6 +34,7 @@ export const instantiateStacks = (app: App, namespace: string, contextEnv: Conte
     contextEnvName: contextEnv.name,
     domainName: contextEnv.domainName,
     hostedZoneTypes: contextEnv.hostedZoneTypes,
+    hostedZoneTypesTest: contextEnv.hostedZoneTypesTest,
   }
 
   const staticHostTypeHints : TypeHint = { additionalAliases: 'csv' }

--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -11,8 +11,11 @@
       "createGithubWebhooks": false,
       "marbleContentBucketName": "testlibnd-smb-test",
       "marbleContentFileShareId": "share-1112707B",
-      "hostedZoneTypes": ["public"]
-    },
+      "hostedZoneTypes": ["public"],
+      "hostedZoneTypesTest": [
+        "private"
+      ]
+      },
     "prod": {
       "account": "230391840102",
       "region": "us-east-1",
@@ -25,7 +28,10 @@
       "createGithubWebhooks": true,
       "marbleContentBucketName": "libnd-smb-marble",
       "marbleContentFileShareId": "share-3CDC3057",
-      "hostedZoneTypes": ["private", "public"]
+      "hostedZoneTypes": ["private", "public"],
+      "hostedZoneTypesTest": [
+        "private"
+      ]
     }
   },
 

--- a/deploy/cdk/lib/cdk-pipeline-deploy.ts
+++ b/deploy/cdk/lib/cdk-pipeline-deploy.ts
@@ -56,6 +56,7 @@ export interface ICDKPipelineDeployProps extends PipelineProjectProps {
    * Any runtime environments needed in addition to the one needed for cdk itself (currently nodejs: '16.x')  e.g. `python: '3.9'`
    */
   readonly additionalRuntimeEnvironments?: { [key: string]: string }
+  readonly stage: string
 }
 
 /**
@@ -117,7 +118,9 @@ export class CDKPipelineDeploy extends Construct {
               `cd $CODEBUILD_SRC_DIR/${props.cdkDirectory || ''}`,
               `npm run cdk deploy -- ${props.targetStack} \
                 --require-approval never --exclusively \
-                -c "namespace=${props.namespace}" -c "env=${props.contextEnvName}" ${addtlContext}`,
+                -c "namespace=${props.namespace}" \
+                -c "stage=${props.stage}" \
+                -c "env=${props.contextEnvName}" ${addtlContext}`,
             ],
           },
           post_build: {

--- a/deploy/cdk/lib/context-env.ts
+++ b/deploy/cdk/lib/context-env.ts
@@ -16,6 +16,7 @@ export class ContextEnv {
   readonly marbleContentBucketName: string
   readonly marbleContentFileShareId: string
   readonly hostedZoneTypes: string[]
+  readonly hostedZoneTypesTest: string[]
 
   static fromContext = (node: Node, name: string): ContextEnv => {
     const contextEnv = getRequiredContext(node, 'environments')[name]

--- a/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
+++ b/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
@@ -174,9 +174,10 @@ class ApiStack extends NestedStack {
 
     // Output API url to ssm so we can import it in the smoke test
     new StringParameter(this, 'ApiUrlParameter', {
-      parameterName: `/all/${this.stackName}/api-url`,
+      parameterName: `/all/stacks/${this.stackName}/api-url`,
       description: 'Path to root of the API gateway.',
       stringValue: iiifApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+      simpleName: false,
     })
 
     new CfnOutput(this, 'ApiEndpointUrl', {

--- a/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
+++ b/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
@@ -33,6 +33,8 @@ export interface IIiifServerlessStackProps extends StackProps {
   readonly paramPathPrefix: string
   readonly domainName: string
   readonly hostedZoneTypes: string[]
+  readonly hostedZoneTypesTest: string[]
+  readonly stage: string
 }
 
 export interface IIiifApiStackProps extends NestedStackProps {
@@ -42,6 +44,8 @@ export interface IIiifApiStackProps extends NestedStackProps {
   readonly hostnamePrefix: string
   readonly domainName: string
   readonly hostedZoneTypes: string[]
+  readonly hostedZoneTypesTest: string[]
+  readonly stage: string
 }
 
 /**
@@ -167,6 +171,13 @@ class ApiStack extends NestedStack {
         })
       }
     }
+
+    // Output API url to ssm so we can import it in the smoke test
+    new StringParameter(this, 'ApiUrlParameter', {
+      parameterName: `/all/${this.stackName}/api-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: iiifApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+    })
 
     new CfnOutput(this, 'ApiEndpointUrl', {
       value: `${iiifApi.url}/iiif/2/`,

--- a/deploy/cdk/lib/image-processing/deployment-pipeline.ts
+++ b/deploy/cdk/lib/image-processing/deployment-pipeline.ts
@@ -44,7 +44,7 @@ export class DeploymentPipelineStack extends Stack {
     const prodStackName = `${props.namespace}-prod-image-processing`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, foundationStack: FoundationStack) => {
+    const createDeploy = (targetStack: string, namespace: string, foundationStack: FoundationStack, stage: string) => {
       const cdkDeploy = new CDKPipelineDeploy(this, `${namespace}-deploy`, {
         targetStack,
         dependsOnStacks: [],
@@ -55,6 +55,7 @@ export class DeploymentPipelineStack extends Stack {
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
         dockerhubCredentialsPath: props.dockerhubCredentialsPath,
+        stage,
         additionalContext: {
           description: "Image processing",
           projectName: "marble",
@@ -111,7 +112,7 @@ export class DeploymentPipelineStack extends Stack {
     })
 
     // Deploy to Test
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, props.testFoundationStack)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, props.testFoundationStack, 'test')
 
     // Approval
     const approvalTopic = new Topic(this, 'ApprovalTopic')
@@ -132,7 +133,7 @@ export class DeploymentPipelineStack extends Stack {
     }
 
     // Deploy to Production
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, props.prodFoundationStack)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, props.prodFoundationStack, 'prod')
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {

--- a/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
+++ b/deploy/cdk/lib/maintain-metadata/deployment-pipeline.ts
@@ -37,7 +37,7 @@ export class DeploymentPipelineStack extends Stack {
     const prodStackName = `${props.namespace}-prod-maintain-metadata`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, deployConstructName: string) => {
+    const createDeploy = (targetStack: string, namespace: string, deployConstructName: string, stage: string) => {
       const cdkDeploy = new CDKPipelineDeploy(this, deployConstructName, {
         targetStack,
         dependsOnStacks: [],
@@ -53,6 +53,7 @@ export class DeploymentPipelineStack extends Stack {
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
         dockerhubCredentialsPath: props.dockerhubCredentialsPath,
+        stage,
         additionalContext: {
           description: "data pipeline for maintaining metadata",
           projectName: "marble",
@@ -130,7 +131,7 @@ export class DeploymentPipelineStack extends Stack {
     
 
     // Deploy to Test
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, `${props.namespace}-maintain-metadata-deploy-test`)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, `${props.namespace}-maintain-metadata-deploy-test`, 'test')
 
     // Approval
     const approvalTopic = new Topic(this, 'ApprovalTopic')
@@ -150,7 +151,7 @@ export class DeploymentPipelineStack extends Stack {
     }
 
     // Deploy to Production
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, `${props.namespace}-maintain-metadata-deploy-prod`)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, `${props.namespace}-maintain-metadata-deploy-prod`, 'prod')
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {

--- a/deploy/cdk/lib/manifest-lambda/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-lambda/deployment-pipeline.ts
@@ -48,7 +48,7 @@ export class DeploymentPipelineStack extends Stack {
     const prodStackName = `${props.namespace}-prod-manifest-lambda`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, deployConstructName: string, publicGraphqlHostnamePrefix: string) => {
+    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, deployConstructName: string, publicGraphqlHostnamePrefix: string, stage: string) => {
       const cdkDeploy = new CDKPipelineDeploy(this, deployConstructName, {
         targetStack,
         dependsOnStacks: [],
@@ -71,6 +71,7 @@ export class DeploymentPipelineStack extends Stack {
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
         dockerhubCredentialsPath: props.dockerhubCredentialsPath,
+        stage,
         additionalContext: {
           description: "data pipeline for creating manifest lambda",
           projectName: "marble",
@@ -180,7 +181,7 @@ export class DeploymentPipelineStack extends Stack {
     // Deploy to Test
     const testHostnamePrefix = `${props.hostnamePrefix}-test`
     const testPublicGraphqlHostnamePrefix = `${props.namespace}-test-${props.publicGraphqlHostnamePrefix}`
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, `${props.namespace}-manifest-lambda-deploy-test`, testPublicGraphqlHostnamePrefix)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, `${props.namespace}-manifest-lambda-deploy-test`, testPublicGraphqlHostnamePrefix, 'test')
     const testHostname = `${testPublicGraphqlHostnamePrefix}.${props.domainName}`
 
     const newmanRunnerTest = new NewmanRunner(this, 'NewmanRunnerTest', {
@@ -212,7 +213,7 @@ export class DeploymentPipelineStack extends Stack {
 
     // Deploy to Production
     const prodPublicGraphqlHostnamePrefix = `${props.namespace}-prod-${props.publicGraphqlHostnamePrefix}`
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, props.hostnamePrefix, `${props.namespace}-manifest-lambda-deploy-prod`, prodPublicGraphqlHostnamePrefix)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, props.hostnamePrefix, `${props.namespace}-manifest-lambda-deploy-prod`, prodPublicGraphqlHostnamePrefix, 'prod')
     const prodHostname = `${prodPublicGraphqlHostnamePrefix}.${props.domainName}`
     const newmanRunnerProd = new NewmanRunner(this, 'NewmanRunnerProd', {
       sourceArtifact: infraSourceArtifact,

--- a/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
+++ b/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
@@ -51,6 +51,8 @@ export interface IBaseStackProps extends StackProps {
    */
   readonly domainName: string
   hostedZoneTypes: string[]
+  readonly hostedZoneTypesTest: string[]
+  readonly stage: string
 }
 
 export class ManifestLambdaStack extends Stack {
@@ -153,6 +155,13 @@ export class ManifestLambdaStack extends Stack {
       }
     }
 
+    // Output API url to ssm so we can import it in the smoke test
+    new StringParameter(this, 'ApiUrlParameter', {
+      parameterName: `/all/${this.stackName}/api-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: this.privateApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+    })
+
     // endpoints
     const manifest = this.privateApi.root.addResource('manifest')
     const manifestId = manifest.addResource('{id}')
@@ -235,6 +244,13 @@ export class ManifestLambdaStack extends Stack {
         })
       }
     }
+
+    // Output API url to ssm so we can import it in the smoke test
+    new StringParameter(this, 'PublicApiUrlParameter', {
+      parameterName: `/all/${this.stackName}/public-api-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: this.publicApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+    })
 
     // Create endpoints
     const query = this.publicApi.root.addResource('query')

--- a/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
+++ b/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
@@ -157,9 +157,10 @@ export class ManifestLambdaStack extends Stack {
 
     // Output API url to ssm so we can import it in the smoke test
     new StringParameter(this, 'ApiUrlParameter', {
-      parameterName: `/all/${this.stackName}/api-url`,
+      parameterName: `/all/stacks/${this.stackName}/api-url`,
       description: 'Path to root of the API gateway.',
       stringValue: this.privateApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+      simpleName: false,
     })
 
     // endpoints
@@ -247,9 +248,10 @@ export class ManifestLambdaStack extends Stack {
 
     // Output API url to ssm so we can import it in the smoke test
     new StringParameter(this, 'PublicApiUrlParameter', {
-      parameterName: `/all/${this.stackName}/public-api-url`,
+      parameterName: `/all/stacks/${this.stackName}/public-api-url`,
       description: 'Path to root of the API gateway.',
       stringValue: this.publicApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+      simpleName: false,
     })
 
     // Create endpoints

--- a/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
+++ b/deploy/cdk/lib/manifest-pipeline/deployment-pipeline.ts
@@ -52,7 +52,7 @@ export class DeploymentPipelineStack extends Stack {
     const prodStackName = `${props.namespace}-prod-manifest`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, imageServiceStackName: string, dataProcessingKeyPath: string, deployConstructName: string, createEventRules: boolean, metadataTimeToLiveDays: string, filesTimeToLiveDays: string, createCopyMediaContentLambda: boolean, createBackup: boolean) => {
+    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, imageServiceStackName: string, dataProcessingKeyPath: string, deployConstructName: string, createEventRules: boolean, metadataTimeToLiveDays: string, filesTimeToLiveDays: string, createCopyMediaContentLambda: boolean, createBackup: boolean, stage: string) => {
 
       const cdkDeploy = new CDKPipelineDeploy(this, deployConstructName, {
         targetStack,
@@ -75,6 +75,7 @@ export class DeploymentPipelineStack extends Stack {
         namespace: `${namespace}`,
         contextEnvName: props.contextEnvName,
         dockerhubCredentialsPath: props.dockerhubCredentialsPath,
+        stage,
         additionalContext: {
           description: "data pipeline for IIIF Manifests",
           projectName: "marble",
@@ -261,7 +262,7 @@ export class DeploymentPipelineStack extends Stack {
 
     // Deploy to Test
     const testHostnamePrefix = `${props.hostnamePrefix}-test`
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, props.imageServiceStackName, props.dataProcessingKeyPath, `${props.namespace}-manifest-deploy-test`, false, props.metadataTimeToLiveDays, props.filesTimeToLiveDays, false, false)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, props.imageServiceStackName, props.dataProcessingKeyPath, `${props.namespace}-manifest-deploy-test`, false, props.metadataTimeToLiveDays, props.filesTimeToLiveDays, false, false, 'test')
 
     // Approval
     const approvalTopic = new Topic(this, 'ApprovalTopic')
@@ -284,7 +285,7 @@ export class DeploymentPipelineStack extends Stack {
     // Deploy to Production
     const createCopyMediaContentLambda = props.contextEnvName === 'prod' ? true : false  // only deploy copy lambda to prod stage in prod environment
     const createBackup = props.contextEnvName === 'prod' ? true : false // only create a dynamoDB backup to prod stage in prod enviornment
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, props.hostnamePrefix, props.prodImageServiceStackName, props.prodDataProcessingKeyPath, `${props.namespace}-manifest-deploy-prod`, true, props.prodMetadataTimeToLiveDays, props.prodFilesTimeToLiveDays, createCopyMediaContentLambda, createBackup)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, props.hostnamePrefix, props.prodImageServiceStackName, props.prodDataProcessingKeyPath, `${props.namespace}-manifest-deploy-prod`, true, props.prodMetadataTimeToLiveDays, props.prodFilesTimeToLiveDays, createCopyMediaContentLambda, createBackup, 'prod')
 
     // Pipeline
     const pipeline = new codepipeline.Pipeline(this, 'DeploymentPipeline', {

--- a/deploy/cdk/lib/multimedia-assets/deployment-pipeline.ts
+++ b/deploy/cdk/lib/multimedia-assets/deployment-pipeline.ts
@@ -45,7 +45,7 @@ export class DeploymentPipelineStack extends Stack {
     const prodHostnamePrefix = props.hostnamePrefix || `${props.namespace}-multimedia`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, foundationStack: FoundationStack) => {
+    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, stage: string) => {
       const cdkDeploy = new CDKPipelineDeploy(this, `${namespace}-deploy`, {
         targetStack,
         dependsOnStacks: [],
@@ -55,6 +55,7 @@ export class DeploymentPipelineStack extends Stack {
         namespace,
         contextEnvName: props.contextEnvName,
         dockerhubCredentialsPath: props.dockerhubCredentialsPath,
+        stage,
         additionalContext: {
           description: props.description,
           projectName: props.projectName,
@@ -106,7 +107,7 @@ export class DeploymentPipelineStack extends Stack {
     })
 
     // Deploy to Test
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, props.testFoundationStack)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, 'test')
 
     const testHostname = `${testHostnamePrefix}.${props.domainName}`
     const newmanRunnerTest = new NewmanRunner(this, 'NewmanRunnerTest', {
@@ -119,7 +120,7 @@ export class DeploymentPipelineStack extends Stack {
     })
 
     // Deploy to Production
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, prodHostnamePrefix, props.prodFoundationStack)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, prodHostnamePrefix, 'prod')
 
     const prodHostname = `${prodHostnamePrefix}.${props.domainName}`
     const newmanRunnerProd = new NewmanRunner(this, 'NewmanRunnerProd', {

--- a/deploy/cdk/lib/multimedia-assets/multimedia-assets-stack.ts
+++ b/deploy/cdk/lib/multimedia-assets/multimedia-assets-stack.ts
@@ -169,9 +169,10 @@ export class MultimediaAssetsStack extends Stack {
 
     // Output API url to ssm so we can import it in the smoke test
     new StringParameter(this, 'ApiUrlParameter', {
-      parameterName: `/all/${this.stackName}/api-url`,
+      parameterName: `/all/stacks/${this.stackName}/api-url`,
       description: 'Path to root of the API gateway.',
       stringValue: this.cloudfront.distributionDomainName,
+      simpleName: false,
     })
 
 

--- a/deploy/cdk/lib/multimedia-assets/multimedia-assets-stack.ts
+++ b/deploy/cdk/lib/multimedia-assets/multimedia-assets-stack.ts
@@ -46,6 +46,8 @@ export interface IMultimediaAssetsStackProps extends StackProps {
   readonly marbleContentBucketName: string
 
   readonly hostedZoneTypes: string[]
+  readonly hostedZoneTypesTest: string[]
+  readonly stage: string
 }
 
 export class MultimediaAssetsStack extends Stack {
@@ -164,6 +166,13 @@ export class MultimediaAssetsStack extends Stack {
         })
       }
     }
+
+    // Output API url to ssm so we can import it in the smoke test
+    new StringParameter(this, 'ApiUrlParameter', {
+      parameterName: `/all/${this.stackName}/api-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: this.cloudfront.distributionDomainName,
+    })
 
 
   }

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -69,7 +69,7 @@ export class DeploymentPipelineStack extends Stack {
     const prodStackName = `${props.namespace}-prod-${props.instanceName}`
 
     // Helper for creating a Pipeline project and action with deployment permissions needed by this pipeline
-    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, buildPath: string, outputArtifact: Artifact, foundationStack: FoundationStack,
+    const createDeploy = (targetStack: string, namespace: string, hostnamePrefix: string, buildPath: string, outputArtifact: Artifact, stage: string,
                           certificateArnPath?: string, domainNameOverride?:string, additionalAliases?: string) => {
 
       const additionalContext = {
@@ -104,6 +104,7 @@ export class DeploymentPipelineStack extends Stack {
         namespace,
         contextEnvName: props.contextEnvName,
         dockerhubCredentialsPath: props.dockerhubCredentialsPath,
+        stage,
         additionalContext: additionalContext,
       })
       cdkDeploy.project.addToRolePolicy(new PolicyStatement({
@@ -199,7 +200,7 @@ export class DeploymentPipelineStack extends Stack {
     const testHostnamePrefix = props.hostnamePrefix ? `${props.hostnamePrefix}-test` : testStackName
     const testBuildPath = `$CODEBUILD_SRC_DIR_${appSourceArtifact.artifactName}`
     const testBuildOutput = new Artifact('TestBuild')
-    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, testBuildPath, testBuildOutput, props.testFoundationStack)
+    const deployTest = createDeploy(testStackName, `${props.namespace}-test`, testHostnamePrefix, testBuildPath, testBuildOutput, 'test')
     const s3syncTestProps: IPipelineS3SyncProps = {
       targetStack: testStackName,
       inputBuildArtifact: appSourceArtifact,
@@ -243,7 +244,7 @@ export class DeploymentPipelineStack extends Stack {
       certificateArnPath = ""
       prodAdditionalAliases = ""
     }
-    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, prodHostnamePrefix, prodBuildPath, prodBuildOutput, props.prodFoundationStack, certificateArnPath, domainNameOverride, prodAdditionalAliases)
+    const deployProd = createDeploy(prodStackName, `${props.namespace}-prod`, prodHostnamePrefix, prodBuildPath, prodBuildOutput, 'prod', certificateArnPath, domainNameOverride, prodAdditionalAliases)
 
     const s3syncProdProps: IPipelineS3SyncProps = {
       targetStack: prodStackName,

--- a/deploy/cdk/lib/static-host/static-host-stack.ts
+++ b/deploy/cdk/lib/static-host/static-host-stack.ts
@@ -40,6 +40,8 @@ export interface IStaticHostStackProps extends StackProps {
   readonly additionalAliases?: Array<string>
   readonly hostedZoneTypes: string[]
   readonly opensearchSecretsKeyPath: string
+  readonly hostedZoneTypesTest: string[]
+  readonly stage: string
 }
 
 export class StaticHostStack extends Stack {
@@ -186,6 +188,13 @@ export class StaticHostStack extends Stack {
       parameterName: `/all/stacks/${this.stackName}/distribution-id`,
       description: 'ID of the CloudFront distribution.',
       stringValue: this.cloudfront.distributionId,
+    })
+
+    // Output API url to ssm so we can import it in the smoke test
+    new StringParameter(this, 'WebsiteUrlParameter', {
+      parameterName: `/all/${this.stackName}/website-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: this.cloudfront.distributionDomainName,
     })
 
     new CfnOutput(this, 'DistributionDomainName', {

--- a/deploy/cdk/lib/static-host/static-host-stack.ts
+++ b/deploy/cdk/lib/static-host/static-host-stack.ts
@@ -192,9 +192,10 @@ export class StaticHostStack extends Stack {
 
     // Output API url to ssm so we can import it in the smoke test
     new StringParameter(this, 'WebsiteUrlParameter', {
-      parameterName: `/all/${this.stackName}/website-url`,
+      parameterName: `/all/stacks/${this.stackName}/website-url`,
       description: 'Path to root of the API gateway.',
       stringValue: this.cloudfront.distributionDomainName,
+      simpleName: false,
     })
 
     new CfnOutput(this, 'DistributionDomainName', {

--- a/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
+++ b/deploy/cdk/test/multimedia-assets/multimedia-assets-stack.test.ts
@@ -24,6 +24,8 @@ describe('MultimediaAssetsStack', () => {
     stackName: 'test-stack-name',
     marbleContentBucketName: 'libnd-smb-marble',
     hostedZoneTypes: ['public'],
+    hostedZoneTypesTest: ['private'],
+    stage: 'test',
   })
 
   test('creates an s3 bucket for assets', () => {


### PR DESCRIPTION
* create parameter store values in stacks to export AWS api gateway and cloudfront names to later use for smoke tests
* added 'stage' and 'hostedZoneTypesTest' parameters to various stacks
Note:  These changes must be deployed before the next set of changes where we actually start using these values.