### PR TITLE
fix api smoke tests

### DIFF
--- a/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
+++ b/deploy/cdk/lib/iiif-serverless/iiif-serverless-stack.ts
@@ -178,7 +178,7 @@ class ApiStack extends NestedStack {
     new StringParameter(this, 'ApiUrlParameter', {
       parameterName: props.parameterStoreKeyPath,
       description: 'Path to root of the API gateway.',
-      stringValue: iiifApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+      stringValue: iiifApi.url,  // iiifApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
       simpleName: false,
     })
 

--- a/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
+++ b/deploy/cdk/lib/manifest-lambda/manifest-lambda-stack.ts
@@ -251,7 +251,7 @@ export class ManifestLambdaStack extends Stack {
     new StringParameter(this, 'PublicApiUrlParameter', {
       parameterName: `/all/stacks/${this.stackName}/public-api-url`,
       description: 'Path to root of the API gateway.',
-      stringValue: this.publicApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
+      stringValue: this.publicApi.url, // this.publicApi.domainName!.domainNameAliasDomainName, // cloudfront the api creates
       simpleName: false,
     })
 


### PR DESCRIPTION
* Change to using api.url instead of api.domainName!domainNameAliasDomainName to try to fix smoke tests for image-service and manifest-lambda.