### PR TITLE
Modify website smoke tests

### DIFF
--- a/deploy/cdk/cdk.context.json
+++ b/deploy/cdk/cdk.context.json
@@ -135,8 +135,6 @@
   "inquisitions:searchIndex": "inquisition",
   "inquisitions:siteDirectory": "",
   "inquisitions:workspaceName": "",
-  "inquisitions:submoduleRepoName": "",
-  "inquisitions:submoduleSourceBranch": "",
   "inquisitions:authClientIssuer": "",
   "inquisitions:authClientUrl": "",
   "inquisitions:authClientId": "",

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -311,7 +311,7 @@ export class DeploymentPipelineStack extends Stack {
           stageName: 'Source',
         },
         {
-          actions: [deployTest.action, s3syncTest.action, smokeTestsProject.action, approvalAction],
+          actions: [deployTest.action, s3syncTest.action, approvalAction],
           stageName: 'Test',
         },
         {

--- a/deploy/cdk/lib/static-host/deployment-pipeline.ts
+++ b/deploy/cdk/lib/static-host/deployment-pipeline.ts
@@ -223,15 +223,15 @@ export class DeploymentPipelineStack extends Stack {
     const s3syncTest = new PipelineS3Sync(this, 'S3SyncTest', s3syncTestProps)
 
     const testHostname = `${testHostnamePrefix}.${props.domainName}`
-    const testHost = StringParameter.valueForStringParameter(this, `/all/stacks/${testStackName}/website-url`)
-    const smokeTestsProject = new NewmanRunner(this, 'StaticHostSmokeTests', {
-      sourceArtifact: appSourceArtifact,
-      collectionPath: props.qaSpecPath,
-      collectionVariables: {
-        'hostname': testHost,
-      },
-      actionName: 'SmokeTests',
-    })
+    // const testHost = StringParameter.valueForStringParameter(this, `/all/stacks/${testStackName}/website-url`)
+    // const smokeTestsProject = new NewmanRunner(this, 'StaticHostSmokeTests', {
+    //   sourceArtifact: appSourceArtifact,
+    //   collectionPath: props.qaSpecPath,
+    //   collectionVariables: {
+    //     'hostname': testHost,
+    //   },
+    //   actionName: 'SmokeTests',
+    // })
 
     // Deploy to Production
     const prodHostnamePrefix = props.hostnamePrefix ? props.hostnamePrefix : `${props.namespace}-${props.instanceName}`
@@ -270,12 +270,12 @@ export class DeploymentPipelineStack extends Stack {
 
     const domainName = domainNameOverride || props.domainName
     const prodHostname = `${prodHostnamePrefix}.${domainName}`
-    const prodHost = StringParameter.valueForStringParameter(this, `/all/stacks/${prodStackName}/website-url`)
+    // const prodHost = StringParameter.valueForStringParameter(this, `/all/stacks/${prodStackName}/website-url`)
     const smokeTestsProd = new NewmanRunner(this, 'StaticHostProdSmokeTests', {
       sourceArtifact: appSourceArtifact,
       collectionPath: props.qaSpecPath,
       collectionVariables: {
-        'hostname': prodHost,
+        'hostname': prodHostname,
       },
       actionName: 'SmokeTests',
     })


### PR DESCRIPTION
* Removed the smoke test from the test stage of static host deployments
* Test the prod stage using the DNS name instead of the cloudfront name stored in parameter store.
